### PR TITLE
Added missing license header

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/examples/simple/parameters/Iterations.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/examples/simple/parameters/Iterations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.snu.cay.services.em.examples.simple.parameters;
 
 import org.apache.reef.tang.annotations.Name;

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/examples/simple/parameters/PeriodMillis.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/examples/simple/parameters/PeriodMillis.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.snu.cay.services.em.examples.simple.parameters;
 
 import org.apache.reef.tang.annotations.Name;


### PR DESCRIPTION
#51 enabled RAT check, but I found that the build fails because 2 files do not have the license header. It seems we missed to check when merging #41. This PR adds the missing license header.
