### PR TITLE
Stop using removed method.

### DIFF
--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/DolphinLauncher.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/DolphinLauncher.java
@@ -56,7 +56,7 @@ public final class DolphinLauncher {
           .getInstance(DolphinLauncher.class)
           .run();
     } catch (final Exception e) {
-      status = LauncherStatus.FAILED(e);
+      status = LauncherStatus.failed(e);
     }
 
     LOG.log(Level.INFO, "REEF job completed: {0}", status);


### PR DESCRIPTION
This is a quick fix: the latest REEF snapshot stopped using the `FAILED` method.
