### PR TITLE
Update REEF to 0.13.0-incubating-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.12.0-incubating-SNAPSHOT</reef.version>
+    <reef.version>0.13.0-incubating-SNAPSHOT</reef.version>
     <hadoop.version>2.4.0</hadoop.version>
     <avro.version>1.7.7</avro.version>
     <jetty.version>6.1.26</jetty.version>


### PR DESCRIPTION
This closes #81 

Contrary to what was written in #81, no changes to CI are needed. We pull in REEF master which is already 0.13.
