### PR TITLE
Fix checkstyle to detect missing whitespace in foreach clauses

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -128,7 +128,9 @@
     <module name="WhitespaceAfter">
       <property name="tokens" value="COMMA, SEMI"/>
     </module>
-    <module name="WhitespaceAround"/>
+    <module name="WhitespaceAround">
+      <property name="ignoreEnhancedForColon" value="false"/>
+    </module>
 
 
     <!-- Modifier Checks                                    -->

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/ClusterSummaryListCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/ClusterSummaryListCodec.java
@@ -57,7 +57,7 @@ public final class ClusterSummaryListCodec implements Codec<List<ClusterSummary>
       daos.writeInt(numClusters);
       daos.writeInt(dimension);
 
-      for (final ClusterSummary clusterSummary: list) {
+      for (final ClusterSummary clusterSummary : list) {
         daos.writeDouble(clusterSummary.getPrior());
         for (int i = 0; i < dimension; i++) {
           daos.writeDouble(clusterSummary.getCentroid().get(i));

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/MapOfIntClusterStatsCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/MapOfIntClusterStatsCodec.java
@@ -43,7 +43,7 @@ public final class MapOfIntClusterStatsCodec implements Codec<Map<Integer, Clust
     final int mapSize = map.size();
     int dimension = 0;
     if (mapSize > 0) {
-      for (final ClusterStats entry: map.values()) {
+      for (final ClusterStats entry : map.values()) {
         dimension = entry.getPointSum().size();
         break;
       }


### PR DESCRIPTION
Fixed the `WhitespaceAround` check to not ignore colons inside `foreach` clauses.

Closes #84.
