### PR TITLE
Resolve the dependency conflict from slf4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.5</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.mahout</groupId>
         <artifactId>mahout-math</artifactId>
         <version>${mahout.version}</version>


### PR DESCRIPTION
Closes #97 

This PR unifies the version of slf4j to 1.7.5 (which is used in REEF) across all the projects. I've tested that Dolphin runs well by applying this change under the dependency to EM.
