### PR TITLE
Fix checkstyle to check TODO comment format

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -185,14 +185,19 @@
       <property name="caseIndent" value="0"/>
     </module>
     <module name="UpperEll"/>
-    <!-- TODO #79 Add TODO comment checkstyle. Currently checks for JIRA comments, and set as warning. -->
-    <module name="TodoComment">
-      <property name="severity" value="warning"/>
-      <property name="format" value="TODO[^\[][^J][^I][^R][^A]"/>
-    </module>
+    <!-- Checks for proper TODO comment format -->
+    <!--
+      All TODO comments should follow the following format:
+        TODO #Number: Comment
+      Throws an checkstyle error if an incorrect format is used.
+    -->
     <module name="TodoComment">
       <property name="severity" value="info"/>
-      <property name="format" value="TODO\[JIRA"/>
+      <property name="format" value="TODO #\d+: .*"/>
+    </module>
+    <module name="TodoComment">
+      <property name="severity" value="error"/>
+      <property name="format" value="TODO(?! #\d+: ).*"/>
     </module>
     <!-- Check that parameters for methods, constructors, and catch blocks are final. -->
     <module name="FinalParameters"/>

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/scheduling/YarnSchedulabilityAnalyzer.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/scheduling/YarnSchedulabilityAnalyzer.java
@@ -17,7 +17,7 @@ package edu.snu.cay.dolphin.scheduling;
 
 import javax.inject.Inject;
 
-// TODO: #92 This class should be implemented and used as a part of changes to support Gang Scheduling in Yarn.
+// TODO #92: This class should be implemented and used as a part of changes to support Gang Scheduling in Yarn.
 /**
  * Not yet implemented, so always returns isSchedulable as true.
  * A future implementation should take into account total Yarn resources and

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/PartitionManager.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/PartitionManager.java
@@ -23,8 +23,8 @@ import java.util.*;
 
 /**
  * Manager class for keeping track of partitions registered by evaluators.
- * TODO: Currently does not check whether ranges are disjoint or not.
- * TODO: Currently does not try to merge contiguous ranges.
+ * TODO #110: Currently does not check whether ranges are disjoint or not.
+ * TODO #111: Currently does not try to merge contiguous ranges.
  */
 @DriverSide
 public final class PartitionManager {

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/ElasticMemoryImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/ElasticMemoryImpl.java
@@ -65,13 +65,13 @@ public final class ElasticMemoryImpl implements ElasticMemory {
         .build());
   }
 
-  // TODO: implement
+  // TODO #112: implement delete
   @Override
   public void delete(final String evalId) {
     throw new NotImplementedException();
   }
 
-  // TODO: implement
+  // TODO #113: implement resize
   @Override
   public void resize(final String evalId, final int megaBytes, final int cores) {
     throw new NotImplementedException();
@@ -93,7 +93,7 @@ public final class ElasticMemoryImpl implements ElasticMemory {
     }
   }
 
-  // TODO: implement
+  // TODO #114: implement checkpoint
   @Override
   public void checkpoint(final String evalId) {
     throw new NotImplementedException();

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/ShuffleDriver.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/ShuffleDriver.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
  * in evaluators through this class.
  *
  * The evaluator-side components can be injected in task or context as a service.
- * // TODO (#63) : Add more explanation about how both cases are different when the functionality is included.
+ * // TODO #63: Add more explanation about how both cases are different when the functionality is included.
  */
 @DriverSide
 @DefaultImplementation(ShuffleDriverImpl.class)

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/impl/StaticPushShuffleCode.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/impl/StaticPushShuffleCode.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.services.shuffle.driver.impl;
 
-// TODO (#88) : Implement functionality
+// TODO #88: Implement functionality
 /**
  * Control message codes for basic shuffle classes.
  */

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/impl/StaticPushShuffleManager.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/driver/impl/StaticPushShuffleManager.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-// TODO (#88) : Implement functionality
+// TODO #88: Implement functionality
 // as a basic implementation of ShuffleManager.
 /**
  * Simple implementation of ShuffleManager.
@@ -112,7 +112,7 @@ public final class StaticPushShuffleManager implements ShuffleManager {
         controlMessageSender.send(endPointId, StaticPushShuffleCode.SHUFFLE_INITIALIZED);
       }
     } catch (final NetworkException e) {
-      // TODO (#67) : failure handling
+      // TODO #67: failure handling
       throw new RuntimeException(e);
     }
   }
@@ -124,7 +124,7 @@ public final class StaticPushShuffleManager implements ShuffleManager {
       final ShuffleControlMessage controlMessage = networkControlMessage.getData().iterator().next();
       if (controlMessage.getCode() == StaticPushShuffleCode.END_POINT_INITIALIZED) {
         if (setupEndPointCount.decrementAndGet() == 0) {
-          // TODO (#88) : This redundant sleep will be removed and StaticPushShuffleManager will be added.
+          // TODO #88: This redundant sleep will be removed and StaticPushShuffleManager will be added.
           try {
             // Wait for all tasks register their EventHandler.
             Thread.sleep(2000);
@@ -151,7 +151,7 @@ public final class StaticPushShuffleManager implements ShuffleManager {
         final Message<ShuffleControlMessage> networkControlMessage) {
       LOG.log(Level.WARNING, "An exception occurred while sending a ShuffleControlMessage. cause : {0}," +
           " socket address : {1}, message : {2}", new Object[]{cause, socketAddress, networkControlMessage});
-      // TODO (#67) : failure handling.
+      // TODO #67: failure handling.
     }
   }
 }

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/ShuffleNetworkSetup.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/ShuffleNetworkSetup.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
  * ShuffleTupleMessage and ShuffleControlMessage.
  */
 @EvaluatorSide
-// TODO (#63) : better naming.
+// TODO #63: better naming.
 public final class ShuffleNetworkSetup {
 
   private final NetworkConnectionService networkConnectionService;

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/impl/StaticPushShuffle.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/impl/StaticPushShuffle.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-// TODO (#88) : Implement functionality.
+// TODO #88: Implement functionality.
 /**
  * Simple implementation of Shuffle.
  *
@@ -160,7 +160,7 @@ public final class StaticPushShuffle<K, V> implements Shuffle<K, V> {
       LOG.log(Level.WARNING, "An exception occurred while sending ShuffleControlMessage to driver. cause : {0}, " +
           "socket address : {1}, message : {2}", new Object[]{throwable, socketAddress, networkControlMessage});
       throw new RuntimeException("An exception occurred while sending ShuffleControlMessage to driver", throwable);
-      // TODO (#67) : failure handling.
+      // TODO #67: failure handling.
     }
   }
 }

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/ShuffleOperatorFactoryImpl.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/ShuffleOperatorFactoryImpl.java
@@ -34,7 +34,7 @@ import javax.inject.Inject;
  */
 final class ShuffleOperatorFactoryImpl<K, V> implements ShuffleOperatorFactory<K, V> {
 
-  // TODO (#63) : currently the identifier of the end point is same as the task identifier.
+  // TODO #63: currently the identifier of the end point is same as the task identifier.
   // It have to be changed for the case Shuffles are injected in context configuration.
   private final String endPointId;
   private final ShuffleDescription shuffleDescription;

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/impl/PushShuffleReceiverImpl.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/impl/PushShuffleReceiverImpl.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 import java.util.List;
 
 /**
- * TODO (#88) : implements base functionality.
+ * TODO #88: implements base functionality.
  */
 public final class PushShuffleReceiverImpl<K, V> implements PushShuffleReceiver<K, V> {
 

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/impl/PushShuffleSenderImpl.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/operator/impl/PushShuffleSenderImpl.java
@@ -21,7 +21,7 @@ import edu.snu.cay.services.shuffle.evaluator.operator.PushShuffleSender;
 import javax.inject.Inject;
 
 /**
- * TODO (#88) : implements base functionality.
+ * TODO #88: implements base functionality.
  */
 public final class PushShuffleSenderImpl<K, V> implements PushShuffleSender<K, V> {
 

--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/example/simple/MessageExchangeTask.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/example/simple/MessageExchangeTask.java
@@ -50,7 +50,7 @@ public final class MessageExchangeTask implements Task {
 
   @Override
   public byte[] call(final byte[] memento) throws Exception {
-    // TODO (#88) : Implement message exchanging using push-based shuffle.
+    // TODO #88: Implement message exchanging using push-based shuffle.
     return null;
   }
 


### PR DESCRIPTION
- Added a check for checking the format of TODO comments.
  - Required format: `TODO #Number: Comment`
- Fixed a few TODO comments to follow the new format.

Closes #79.
