### PR TITLE
Issue 121 extend test of partition manager

### DIFF
--- a/services/elastic-memory/src/test/java/edu/snu/cay/services/em/driver/PartitionManagerTest.java
+++ b/services/elastic-memory/src/test/java/edu/snu/cay/services/em/driver/PartitionManagerTest.java
@@ -33,8 +33,8 @@ import static org.junit.Assert.*;
  */
 public final class PartitionManagerTest {
 
-  // Before use, put index at the end of these prefixes.
-  // For single evaluator or single data type case, just use these prefixes without change for convenience.
+  // Put evaluator id or data type index at the end of these prefixes before use.
+  // For single evaluator or single data type case, just use these prefixes without changing them for convenience.
   private static final String EVAL_ID_PREFIX = "Evaluator-";
   private static final String DATA_TYPE_PREFIX = "DATA_TYPE_";
   private static final String MSG_SIZE_ASSERTION = "size of final partition manager";
@@ -254,9 +254,9 @@ public final class PartitionManagerTest {
 
   /**
    * Testing multi-thread addition, removal, and retrieval on disjoint id ranges.
-   * Use more than one evaluators to test this.
-   * Check that the consistency of a MemoryStore is preserved when multiple evaluators
-   * on multiple threads try to add, remove, and retrieve disjoint ranges concurrently.
+   * This test use more than one evaluator id index.
+   * Check that the consistency of a MemoryStore is preserved when multiple threads try to
+   * add, remove, and retrieve disjoint ranges concurrently using multiple evaluator id indexes.
    */
   @Test
   public void testMultithreadMultiEvaluatorAddGetRemoveDisjointRanges() throws InterruptedException {
@@ -282,7 +282,6 @@ public final class PartitionManagerTest {
     // Thus, we partition the objects set so that AddThreads and RemoveThreads
     // never access the same object.
     // Hence the IndexParity.EVEN_INDEX and IndexParity.ODD_INDEX.
-    // Be careful with handling indexes to completely remove exact objects in exact evaluator ids.
     for (int index = 0; index < numThreadsPerOperation; index++) {
       threads[3 * index] = new RegisterThread(countDownLatch, partitionManager, index, numThreadsPerOperation,
           addsPerThread, IndexParity.EVEN_INDEX, EVAL_ID_PREFIX + index, DATA_TYPE_PREFIX);
@@ -306,9 +305,9 @@ public final class PartitionManagerTest {
 
   /**
    * Testing multi-thread addition, removal, and retrieval on disjoint id ranges.
-   * Use more than one data types to test this.
-   * Check that the consistency of a MemoryStore is preserved
-   * when multiple threads try to add, remove, and retrieve disjoint ranges of data types concurrently.
+   * This test use more than one data type index.
+   * Check that the consistency of a MemoryStore is preserved when multiple threads try to
+   * add, remove, and retrieve disjoint ranges of multiple data types concurrently.
    */
   @Test
   public void testMultithreadMultiDataTypeAddGetRemoveDisjointRanges() throws InterruptedException {
@@ -334,7 +333,6 @@ public final class PartitionManagerTest {
     // Thus, we partition the objects set so that AddThreads and RemoveThreads
     // never access the same object.
     // Hence the IndexParity.EVEN_INDEX and IndexParity.ODD_INDEX.
-    // Be careful with handling indexes to completely remove exact objects in exact data types.
     for (int index = 0; index < numThreadsPerOperation; index++) {
       threads[3 * index] = new RegisterThread(countDownLatch, partitionManager, index, numThreadsPerOperation,
           addsPerThread, IndexParity.EVEN_INDEX, EVAL_ID_PREFIX, DATA_TYPE_PREFIX + index);
@@ -358,9 +356,9 @@ public final class PartitionManagerTest {
 
   /**
    * Testing multi-thread addition, removal, and retrieval on disjoint id ranges.
-   * Use more than one evaluators and data types to test this.
-   * Check that the consistency of a MemoryStore is preserved when multiple evaluators
-   * on multiple threads try to add, remove, and retrieve disjoint ranges of data types concurrently.
+   * This test use more than one evaluator id and data type index.
+   * Check that the consistency of a MemoryStore is preserved when multiple threads try to
+   * add, remove, and retrieve disjoint ranges of multiple data types concurrently using multiple evaluator id indexes.
    */
   @Test
   public void testMultithreadMultiEvaluatorMultiDataTypeAddGetRemoveDisjointRanges() throws InterruptedException {
@@ -389,7 +387,6 @@ public final class PartitionManagerTest {
     // Thus, we partition the objects set so that AddThreads and RemoveThreads
     // never access the same object.
     // Hence the IndexParity.EVEN_INDEX and IndexParity.ODD_INDEX.
-    // Be careful with handling indexes to completely remove exact objects in exact evaluators and data types.
     for (int index = 0; index < numThreadsPerOperation; index++) {
       final int evalIndex = index / 2 % 4;
       final int dataTypeIndex = index % 2;


### PR DESCRIPTION
This PR extends PartitionManagerTest to handle cases with multiple evaluators and multiple data types.
- Add three tests:
  - multi-thread add & remove & get on multiple evaluators
  - multi-thread add & remove & get with multiple data types
  - multi-thread add & remove & get on multiple evaluators with multiple data types
- Modify RegisterThread, RemoveThread, GetThread to get evaluator id and data type as parameter of constructor.
