### PR TITLE
Add getDataTypes and getNumUnits API to SubMemoryStore

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/api/SubMemoryStore.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/api/SubMemoryStore.java
@@ -20,6 +20,7 @@ import org.apache.reef.io.network.util.Pair;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Evaluator-side interface of SubMemoryStore.
@@ -110,4 +111,19 @@ public interface SubMemoryStore {
    * @return map of data ids and the corresponding data items
    */
   <T> Map<Long, T> removeRange(String dataType, long startId, long endId);
+
+  /**
+   * Fetch all data types of items residing in this store, without duplicates.
+   *
+   * @return a set of strings that indicate the data types in this store
+   */
+  Set<String> getDataTypes();
+
+  /**
+   * Fetch the number of items associated with a certain data type.
+   *
+   * @param dataType string that represents a certain data type
+   * @return number of items associated with {@code dataType}
+   */
+  int getNumUnits(String dataType);
 }

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/SubMemoryStoreImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/SubMemoryStoreImpl.java
@@ -195,4 +195,38 @@ public final class SubMemoryStoreImpl implements SubMemoryStore {
       readWriteLock.writeLock().unlock();
     }
   }
+
+  @Override
+  public Set<String> getDataTypes() {
+    readWriteLock.readLock().lock();
+
+    try {
+      final Set<String> dataTypeSet = new HashSet<>(dataMap.keySet().size());
+      for (final Map.Entry<String, TreeMap<Long, Object>> entry : dataMap.entrySet()) {
+        if (!entry.getValue().isEmpty()) {
+          dataTypeSet.add(entry.getKey());
+        }
+      }
+
+      return dataTypeSet;
+
+    } finally {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public int getNumUnits(final String dataType) {
+    readWriteLock.readLock().lock();
+
+    try {
+      if (!dataMap.containsKey(dataType)) {
+        return 0;
+      }
+      return dataMap.get(dataType).size();
+
+    } finally {
+      readWriteLock.readLock().unlock();
+    }
+  }
 }


### PR DESCRIPTION
This PR adds the following methods to `SubMemoryStore` and the implementation `SubMemoryStoreImpl`.
- `getDataTypes()`: return all data types of a memory store
- `getNumUnits(dataType)`: return the number of units for `dataType`

Closes #154.
