### PR TITLE
[MINOR] Change dolphin/bin example usage for clustering to use three clusters

### DIFF
--- a/dolphin/bin/run_em.sh
+++ b/dolphin/bin/run_em.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_em.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input sample_cluster -output output_em -maxNumEvalLocal 5
+# ./run_em.sh -numCls 3 -convThr 0.01 -maxIter 20 -local true -split 4 -input sample_cluster -output output_em -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/dolphin/bin/run_kmeans.sh
+++ b/dolphin/bin/run_kmeans.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_kmeans.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input sample_cluster -output output_kmeans -maxNumEvalLocal 5
+# ./run_kmeans.sh -numCls 3 -convThr 0.01 -maxIter 20 -local true -split 4 -input sample_cluster -output output_kmeans -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar


### PR DESCRIPTION
Makes the example usage match the sample file well (which is also generated from 3 clusters).

I don't recall if we allow minor PRs in cay. If not, I'll file a proper issue as well.
