### PR TITLE
[MINOR] Remove redundant line in ShuffleProvider

### DIFF
--- a/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/ShuffleProvider.java
+++ b/services/shuffle/src/main/java/edu/snu/cay/services/shuffle/evaluator/ShuffleProvider.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.cay.services.shuffle.evaluator;
 
-import edu.snu.cay.services.shuffle.network.TupleNetworkSetup;
 import edu.snu.cay.services.shuffle.params.ShuffleParameters;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.annotations.Parameter;
@@ -62,7 +61,6 @@ public final class ShuffleProvider implements AutoCloseable {
   private void deserializeShuffle(final String serializedShuffle) {
     try {
       final Injector injector = rootInjector.forkInjector(confSerializer.fromString(serializedShuffle));
-      injector.getInstance(TupleNetworkSetup.class);
       final Shuffle shuffle = injector.getInstance(Shuffle.class);
       shuffleMap.put(shuffle.getShuffleDescription().getShuffleName(), shuffle);
     } catch (final Exception e) {


### PR DESCRIPTION
Thanks to #198, the pre-instantiation of `TupleNetworkSetup` in `ShuffleProvider` is no longer needed. This PR removes that line.
