### PR TITLE
[MINOR] For messaging related logs at Tasks, reduce level of logging to FINE

### DIFF
--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/ComputeTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/ComputeTask.java
@@ -274,7 +274,7 @@ public final class ComputeTask implements Task {
         .setCommGroupName(commGroup.getName().getName())
         .build();
 
-    LOG.log(Level.INFO, "iterationInfo {0}", iterationInfo);
+    LOG.log(Level.FINE, "iterationInfo {0}", iterationInfo);
     return iterationInfo;
   }
 
@@ -291,7 +291,7 @@ public final class ComputeTask implements Task {
     final ComputeMsg computeMsg = ComputeMsg.newBuilder()
         .setDataInfos(dataInfos)
         .build();
-    LOG.log(Level.INFO, "computeMsg {0}", computeMsg);
+    LOG.log(Level.FINE, "computeMsg {0}", computeMsg);
     return computeMsg;
   }
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/ControllerTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/ControllerTask.java
@@ -183,14 +183,14 @@ public final class ControllerTask implements Task {
         .setCommGroupName(commGroup.getName().getName())
         .build();
 
-    LOG.log(Level.INFO, "iterationInfo {0}", iterationInfo);
+    LOG.log(Level.FINE, "iterationInfo {0}", iterationInfo);
     return iterationInfo;
   }
 
   private ControllerMsg getControllerMsg() {
     final ControllerMsg controllerMsg = ControllerMsg.newBuilder()
         .build();
-    LOG.log(Level.INFO, "controllerMsg {0}", controllerMsg);
+    LOG.log(Level.FINE, "controllerMsg {0}", controllerMsg);
     return controllerMsg;
   }
 }


### PR DESCRIPTION
The messaging related logs seemed to verbose, so I reduced them to FINE. This should be more in line with other logging in Dolphin.
