### PR TITLE
Introduce Cobertura plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.snu.cay</groupId>
@@ -66,7 +66,7 @@
     <module>services/shuffle</module>
     <module>utils</module>
   </modules>
-  
+
   <dependencyManagement>
     <dependencies>
       <!-- REEF -->
@@ -265,6 +265,11 @@
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -290,6 +295,27 @@
             <phase>validate</phase>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <configuration>
+          <instrumentation>
+            <excludes>
+              <exclude>edu/snu/cay/dolphin/examples/**/*.class</exclude>
+              <exclude>edu/snu/cay/services/em/examples/**/*.class</exclude>
+              <exclude>edu/snu/cay/services/shuffle/examples/**/*.class</exclude>
+            </excludes>
+          </instrumentation>
+          <aggregate>true</aggregate>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>clean</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This PR introduces Cobertura plugin. After executing command `mvn cobertura:cobertura`, you can find aggregate report at `cay/target/site/cobertura/index.html`.
I excluded `examples` packages, so the report does not check test coverage for dolphin, em, shuffle examples.
Our current state is 30% line coverage and 27% branch coverage.

This closes #252
