### PR TITLE
[MINOR] Log the plan immediately after optimize

### DIFF
--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/optimizer/OptimizationOrchestrator.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/optimizer/OptimizationOrchestrator.java
@@ -127,9 +127,9 @@ public final class OptimizationOrchestrator {
         getEvaluatorParameters(dataInfos, computeMetrics, controllerId, controllerMetrics),
         getAvailableEvaluators(computeMetrics.size()));
 
-    planExecutionResult = planExecutor.execute(plan);
+    LOG.log(Level.INFO, "Optimization complete. Executing plan: {0}", plan);
 
-    LOG.log(Level.INFO, "Optimization complete.");
+    planExecutionResult = planExecutor.execute(plan);
   }
 
   private boolean isPlanExecuting() {


### PR DESCRIPTION
Now logging the plan.
The location of the previous log message was confusing because it was after the `execute()` call.
