### PR TITLE
Update REEF version to 0.14.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.14.0-incubating-SNAPSHOT</reef.version>
+    <reef.version>0.14.0-SNAPSHOT</reef.version>
     <hadoop.version>2.6.0</hadoop.version>
     <htrace.version>3.0.4</htrace.version>
     <mahout.version>0.9</mahout.version>


### PR DESCRIPTION
This PR updates the REEF version in our `pom.xml`.

In #279, @gwsshs22 mentioned tests will fail due to the REEF dependency, but tests passed. This is  because the build server has both version in the local maven repository. So, even after merging this, #279's tests will still pass, and there would be no merge conflict.
