### PR TITLE
[MINOR] Add Tang dependency to utils/pom.xml

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -35,6 +35,10 @@
       <artifactId>reef-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.reef</groupId>
+      <artifactId>tang</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Some classes in `cay-utils` import and use Tang classes, but the dependency is not included in the modules's pom. This occasionally causes errors in IntelliJ. This PR adds the Tang dependency to the pom of `cay-utils`.
