### PR TITLE
Fix: Add an injectable constructor in EMDeleteExecutorImpl

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/EMDeleteExecutorImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/EMDeleteExecutorImpl.java
@@ -19,10 +19,17 @@ import edu.snu.cay.services.em.avro.AvroElasticMemoryMessage;
 import edu.snu.cay.services.em.driver.api.EMDeleteExecutor;
 import org.apache.reef.wake.EventHandler;
 
+import javax.inject.Inject;
+
 /**
  * Default implementation of EMDeleteExecutor.
  */
 public final class EMDeleteExecutorImpl implements EMDeleteExecutor {
+
+  @Inject
+  private EMDeleteExecutorImpl() {
+
+  }
 
   @Override
   public void execute(final String activeContextId, final EventHandler<AvroElasticMemoryMessage> callback) {


### PR DESCRIPTION
This PR is for resolving a crash of `SimpleEMREEF`, an example app of EM.

`EMDeleteExecutorImpl` is an one (default) of implementations  of `EMDeleteExecutor`, and it is not completely built yet. A problem is that it does not have an injectable constructor and `SimpleEMREEF`, an example app of EM crashes by this. I guess it happens by mistake or a later update to the example, which injects `EMDeleteExecutor`.

I fixed it by simply putting an injectable constructor.

Only a `SimpleEMREEF` example of EM crashes and Dolphins's example apps have worked well; it is because that `DolphinLauncher` binds `TaskRemover`, a Dolphin-specific implementation, to `EMDeleteExecutor` interface.
