### PR TITLE
Initialize group comm operators before starting stage

### DIFF
--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/ComputeTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/ComputeTask.java
@@ -150,6 +150,7 @@ public final class ComputeTask implements Task {
     final TraceInfo taskTraceInfo = memento == null ? null :
         HTraceUtils.fromAvro(hTraceInfoCodec.decode(memento));
 
+    initializeGroupCommOperators();
     userComputeTask.initialize();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -195,6 +196,21 @@ public final class ComputeTask implements Task {
 
     shuffleProvider.close();
     return null;
+  }
+
+  private void initializeGroupCommOperators() {
+    if (userComputeTask.isBroadcastUsed()) {
+      commGroup.getBroadcastReceiver(DataBroadcast.class);
+    }
+    if (userComputeTask.isScatterUsed()) {
+      commGroup.getScatterReceiver(DataScatter.class);
+    }
+    if (userComputeTask.isGatherUsed()) {
+      commGroup.getGatherSender(DataGather.class);
+    }
+    if (userComputeTask.isReduceUsed()) {
+      commGroup.getReduceSender(DataReduce.class);
+    }
   }
 
   private void runUserComputeTask() throws MetricException {

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/core/ControllerTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/core/ControllerTask.java
@@ -100,6 +100,7 @@ public final class ControllerTask implements Task {
     final TraceInfo taskTraceInfo = memento == null ? null :
         HTraceUtils.fromAvro(hTraceInfoCodec.decode(memento));
 
+    initializeGroupCommOperators();
     userControllerTask.initialize();
     try (final MetricsCollector metricsCollector = this.metricsCollector;) {
       metricsCollector.registerTrackers(metricTrackerSet);
@@ -135,6 +136,21 @@ public final class ControllerTask implements Task {
   private void updateTopology() {
     if (commGroup.getTopologyChanges().exist()) {
       commGroup.updateTopology();
+    }
+  }
+
+  private void initializeGroupCommOperators() {
+    if (userControllerTask.isBroadcastUsed()) {
+      commGroup.getBroadcastSender(DataBroadcast.class);
+    }
+    if (userControllerTask.isScatterUsed()) {
+      commGroup.getScatterSender(DataScatter.class);
+    }
+    if (userControllerTask.isGatherUsed()) {
+      commGroup.getGatherReceiver(DataGather.class);
+    }
+    if (userControllerTask.isReduceUsed()) {
+      commGroup.getReduceReceiver(DataReduce.class);
     }
   }
 


### PR DESCRIPTION
This PR adds an initialization method so that all operators are clearly registered before a stage starts. This fixes a bug where communication messages for operators not registered yet get sent and received, resulting in a null pointer exception.
