### PR TITLE
Add wrapper for Breeze matrix

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.scalanlp</groupId>
       <artifactId>breeze_2.10</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/Matrix.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/Matrix.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg;
+
+/**
+ * Interface for matrix whose elements are {@code double} values.
+ * Linear indexing is in column-major order, unless the matrix is transposed.
+ */
+public interface Matrix {
+
+  /**
+   * Returns the number of elements.
+   * @return number of elements
+   */
+  int size();
+
+  /**
+   * Returns the number of active elements.
+   * @return number of active elements
+   */
+  int activeSize();
+
+  /**
+   * Returns true if the matrix is dense, false if sparse.
+   * @return true if the matrix is dense, false if sparse
+   */
+  boolean isDense();
+
+  /**
+   * Returns the number of rows.
+   * @return number of rows
+   */
+  int getRows();
+
+  /**
+   * Returns the number of columns.
+   * @return number of columns
+   */
+  int getColumns();
+
+  /**
+   * Returns a element specified by the row and column indices.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @return element specified by given indices
+   */
+  double get(int rowIndex, int columnIndex);
+
+  /**
+   * Sets a matrix element.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @param value given value
+   */
+  void set(int rowIndex, int columnIndex, double value);
+
+  /**
+   * Transpose this matrix.
+   * @return transposed copy of this matrix
+   */
+  Matrix transpose();
+
+  /**
+   * Returns a new matrix same as this one.
+   * @return copied new matrix
+   */
+  Matrix copy();
+
+  /**
+   * Element-wise adds a matrix.
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix add(Matrix matrix);
+
+  /**
+   * Element-wise adds a matrix (in place).
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix addi(Matrix matrix);
+
+  /**
+   * Element-wise subtracts a matrix.
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix sub(Matrix matrix);
+
+  /**
+   * Element-wise subtracts a matrix (in place).
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix subi(Matrix matrix);
+
+  /**
+   * Multiplies a scalar to all elements.
+   * @param value operand scalar
+   * @return operation result
+   */
+  Matrix mul(double value);
+
+  /**
+   * Multiplies a scalar to all elements (in place).
+   * @param value operand scalar
+   * @return operation result
+   */
+  Matrix muli(double value);
+
+  /**
+   * Matrix-Matrix element-wise multiplication.
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix mul(Matrix matrix);
+
+  /**
+   * Matrix-Matrix element-wise multiplication (in place).
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix muli(Matrix matrix);
+
+  /**
+   * Matrix-Vector multiplication.
+   * @param vector operand vector
+   * @return operation result
+   */
+  Vector mmul(Vector vector);
+  /**
+   * Matrix-Matrix multiplication.
+   * @param matrix operand matrix
+   * @return operation result
+   */
+  Matrix mmul(Matrix matrix);
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/MatrixFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/MatrixFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg;
+
+import edu.snu.cay.common.math.linalg.breeze.DefaultMatrixFactory;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
+import java.util.List;
+
+/**
+ * Factory interface for {@link Matrix}.
+ */
+@DefaultImplementation(DefaultMatrixFactory.class)
+public interface MatrixFactory {
+
+  /**
+   * Creates a dense matrix in which all elements are equal to {@code 0}.
+   * @param rows number of rows
+   * @param columns number of columns
+   * @return a generated matrix
+   */
+  Matrix createDenseZeros(int rows, int columns);
+
+  /**
+   * Creates a dense matrix with the given values.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @param data elements of a matrix in column-major order
+   * @return a generated matrix
+   */
+  Matrix createDense(int rows, int columns, double[] data);
+
+  /**
+   * Creates a CSC matrix in which all elements are equal to {@code 0}.
+   * @param rows number of rows
+   * @param columns number of columns
+   * @param initialNonZeros number of initial nonZeros
+   * @return a generated matrix
+   */
+  Matrix createCSCZeros(int rows, int columns, int initialNonZeros);
+
+  /**
+   * Creates a dense matrix by horizontal concatenation of vectors.
+   * All vectors should have the same length.
+   * @param vectors list of concatenating vectors
+   * @return a generated matrix
+   */
+  Matrix horzcatDense(List<Vector> vectors);
+
+  /**
+   * Creates a CSC matrix by horizontal concatenation of vectors.
+   * All vectors should have the same length.
+   * @param vectors list of concatenating vectors
+   * @return a generated matrix
+   */
+  Matrix horzcatSparse(List<Vector> vectors);
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/Vector.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/Vector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector;
+package edu.snu.cay.common.math.linalg;
 
 /**
  * Interface for vector whose elements are {@code double} values.

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/VectorEntry.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/VectorEntry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector;
+package edu.snu.cay.common.math.linalg;
 
 /**
  * Class for vector iteration.

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/VectorFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/VectorFactory.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector;
+package edu.snu.cay.common.math.linalg;
 
-import edu.snu.cay.common.math.vector.breeze.DefaultVectorFactory;
+import edu.snu.cay.common.math.linalg.breeze.DefaultVectorFactory;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/CSCMatrix.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/CSCMatrix.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import breeze.linalg.NumericOps;
+import edu.snu.cay.common.math.linalg.Matrix;
+import edu.snu.cay.common.math.linalg.Vector;
+
+/**
+ * Matrix implementation based on breeze CSC(Compressed Sparse Column) matrix.
+ * This class should be initialized by {@link edu.snu.cay.common.math.linalg.MatrixFactory}.
+ */
+public final class CSCMatrix implements Matrix {
+
+  private final breeze.linalg.CSCMatrix<Double> breezeMatrix;
+
+  CSCMatrix(final breeze.linalg.CSCMatrix<Double> breezeMatrix) {
+    this.breezeMatrix = breezeMatrix;
+  }
+
+  breeze.linalg.CSCMatrix<Double> getBreezeMatrix() {
+    return breezeMatrix;
+  }
+
+  /**
+   * Returns the number of elements.
+   * @return number of elements
+   */
+  @Override
+  public int size() {
+    return breezeMatrix.size();
+  }
+
+  /**
+   * Returns the number of active elements.
+   * @return number of active elements
+   */
+  @Override
+  public int activeSize() {
+    return breezeMatrix.activeSize();
+  }
+
+  /**
+   * Returns true if the matrix is dense, false if sparse.
+   * @return false
+   */
+  @Override
+  public boolean isDense() {
+    return false;
+  }
+
+  /**
+   * Returns the number of rows.
+   * @return number of rows
+   */
+  @Override
+  public int getRows() {
+    return breezeMatrix.rows();
+  }
+
+  /**
+   * Returns the number of columns.
+   * @return number of columns
+   */
+  @Override
+  public int getColumns() {
+    return breezeMatrix.cols();
+  }
+
+  /**
+   * Returns a element specified by the row and column indices.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @return element specified by given indices
+   */
+  @Override
+  public double get(final int rowIndex, final int columnIndex) {
+    return breezeMatrix.apply(rowIndex, columnIndex);
+  }
+
+  /**
+   * Sets a matrix element.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @param value given value
+   */
+  @Override
+  public void set(final int rowIndex, final int columnIndex, final double value) {
+    breezeMatrix.update(rowIndex, columnIndex, value);
+  }
+
+  /**
+   * Transpose this matrix.
+   * @return transposed copy of this matrix
+   */
+  @Override
+  public Matrix transpose() {
+    return new CSCMatrix((breeze.linalg.CSCMatrix<Double>) breezeMatrix.t(MatrixOps.T_S));
+  }
+
+  /**
+   * Returns a new matrix same as this one.
+   * @return copied new matrix
+   */
+  @Override
+  public Matrix copy() {
+    return new CSCMatrix(breezeMatrix.copy());
+  }
+
+  @Override
+  public String toString() {
+    return breezeMatrix.toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o instanceof CSCMatrix) {
+      return breezeMatrix.equals(((CSCMatrix) o).breezeMatrix);
+    }
+    if (o instanceof DenseMatrix) {
+      return breezeMatrix.equals(((DenseMatrix) o).getBreezeMatrix());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return breezeMatrix.hashCode();
+  }
+
+  /**
+   * Element-wise adds a matrix.
+   * The result is {@link DenseMatrix} if the operand is {@link DenseMatrix},
+   * {@link CSCMatrix} otherwise.
+   * @param matrix operand matrix
+   * @return new matrix with operation result
+   */
+  @Override
+  public Matrix add(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          ((DenseMatrix) matrix).getBreezeMatrix().$plus(breezeMatrix, MatrixOps.ADD_DS));
+    } else {
+      return new CSCMatrix((breeze.linalg.CSCMatrix<Double>)
+          breezeMatrix.$plus(((CSCMatrix) matrix).breezeMatrix, MatrixOps.ADD_SS));
+    }
+  }
+
+  /**
+   * Element-wise adds a matrix.
+   * Throws {@code UnsupportedOperationException} if the operand is {@link DenseMatrix}.
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix addi(final Matrix matrix) {
+    if (matrix.isDense()) {
+      throw new UnsupportedOperationException();
+    } else {
+      ((NumericOps) breezeMatrix).$plus$eq(((CSCMatrix) matrix).breezeMatrix, MatrixOps.ADDI_SS);
+      return this;
+    }
+  }
+
+  /**
+   * Element-wise subtracts a matrix.
+   * The result is {@link DenseMatrix} if the operand is {@link DenseMatrix},
+   * {@link CSCMatrix} otherwise.
+   * @param matrix operand matrix
+   * @return new matrix with operation result
+   */
+  @Override
+  public Matrix sub(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          ((DenseMatrix) matrix).getBreezeMatrix().$minus(breezeMatrix, MatrixOps.SUB_DS));
+    } else {
+      return new CSCMatrix((breeze.linalg.CSCMatrix<Double>)
+          breezeMatrix.$minus(((CSCMatrix) matrix).breezeMatrix, MatrixOps.SUB_SS));
+    }
+  }
+
+  /**
+   * Element-wise subtracts a matrix (in place).
+   * Throws {@code UnsupportedOperationException} if the operand is {@link DenseMatrix}.
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix subi(final Matrix matrix) {
+    if (matrix.isDense()) {
+      throw new UnsupportedOperationException();
+    } else {
+      ((NumericOps) breezeMatrix).$minus$eq(((CSCMatrix) matrix).breezeMatrix, MatrixOps.SUBI_SS);
+      return this;
+    }
+  }
+
+  /**
+   * Multiplies a scalar to all elements.
+   * @param value operand scalar
+   * @return new {@link CSCMatrix} with operation result
+   */
+  @Override
+  public Matrix mul(final double value) {
+    return new CSCMatrix((breeze.linalg.CSCMatrix<Double>) breezeMatrix.$colon$times(value, MatrixOps.MUL_ST));
+  }
+
+  /**
+   * Multiplies a scalar to all elements (in place).
+   * @param value operand scalar
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix muli(final double value) {
+    ((NumericOps) breezeMatrix).$colon$times$eq(value, MatrixOps.MULI_ST);
+    return this;
+  }
+
+  /**
+   * Matrix-Matrix element-wise multiplication.
+   * Throws {@code UnsupportedOperationException} if the operand is {@link DenseMatrix}.
+   * @param matrix operand matrix
+   * @return new {@link CSCMatrix} operation result
+   */
+  @Override
+  public Matrix mul(final Matrix matrix) {
+    if (matrix.isDense()) {
+      throw new UnsupportedOperationException();
+    } else {
+      return new CSCMatrix((breeze.linalg.CSCMatrix<Double>)
+          breezeMatrix.$colon$times(((CSCMatrix) matrix).breezeMatrix, MatrixOps.EMUL_SS));
+    }
+  }
+
+  /**
+   * Matrix-Matrix element-wise multiplication (in place).
+   * Throws {@code UnsupportedOperationException} if the operand is {@link DenseMatrix}.
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix muli(final Matrix matrix) {
+    if (matrix.isDense()) {
+      throw new UnsupportedOperationException();
+    } else {
+      ((NumericOps) breezeMatrix).$colon$times$eq(((CSCMatrix) matrix).breezeMatrix, MatrixOps.EMULI_SS);
+      return this;
+    }
+  }
+
+  /**
+   * Matrix-Vector multiplication.
+   * The result is {@link DenseVector} if the operand is {@link DenseVector},
+   * {@link SparseVector} otherwise.
+   * @param vector operand vector
+   * @return new vector with operation result
+   */
+  @Override
+  public Vector mmul(final Vector vector) {
+    if (vector.isDense()) {
+      return new DenseVector((breeze.linalg.DenseVector<Double>)
+          breezeMatrix.$times(((DenseVector) vector).getBreezeVector(), MatrixOps.MUL_SMDV));
+    } else {
+      return new SparseVector((breeze.linalg.SparseVector<Double>)
+          breezeMatrix.$times(((SparseVector) vector).getBreezeVector(), MatrixOps.MUL_SMSV));
+    }
+  }
+
+  /**
+   * Matrix-Matrix multiplication.
+   * The result is {@link DenseMatrix} if the operand is {@link DenseMatrix},
+   * {@link CSCMatrix} otherwise.
+   * @param matrix operand matrix
+   * @return new matrix with operation result
+   */
+  @Override
+  public Matrix mmul(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$times(((DenseMatrix) matrix).getBreezeMatrix(), MatrixOps.MUL_SMDM));
+    } else {
+      return new CSCMatrix((breeze.linalg.CSCMatrix<Double>)
+          breezeMatrix.$times(((CSCMatrix) matrix).breezeMatrix, MatrixOps.MUL_SMSM));
+    }
+  }
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultMatrixFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultMatrixFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import breeze.storage.Zero;
+import breeze.storage.Zero$;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import edu.snu.cay.common.math.linalg.MatrixFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import scala.collection.JavaConversions;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Factory class for breeze based matrix.
+ */
+public final class DefaultMatrixFactory implements MatrixFactory {
+
+  private static final ClassTag TAG = ClassTag$.MODULE$.Double();
+  private static final Zero ZERO = Zero$.MODULE$.forClass(Double.TYPE);
+
+  @Inject
+  private DefaultMatrixFactory() {
+  }
+
+  /**
+   * Creates a dense matrix in which all elements are equal to {@code 0}.
+   * @param rows number of rows
+   * @param columns number of columns
+   * @return a generated matrix
+   */
+  @Override
+  public DenseMatrix createDenseZeros(final int rows, final int columns) {
+    return new DenseMatrix(breeze.linalg.DenseMatrix.zeros(rows, columns, TAG, ZERO));
+  }
+
+  /**
+   * Creates a dense matrix with the given values.
+   * This method does not make a deep copy of {@code data}.
+   * Thus, changes in {@code data} also change the returning matrix.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @param data elements of a matrix in column-major order
+   * @return a generated matrix
+   */
+  @Override
+  public DenseMatrix createDense(final int rows, final int columns, final double[] data) {
+    return new DenseMatrix(breeze.linalg.DenseMatrix.create(rows, columns, data, ZERO));
+  }
+
+  /**
+   * Creates a CSC matrix in which all elements are equal to {@code 0}.
+   * @param rows number of rows
+   * @param columns number of columns
+   * @param initialNonZeros number of initial nonZeros
+   * @return a generated matrix
+   */
+  @Override
+  public CSCMatrix createCSCZeros(final int rows, final int columns, final int initialNonZeros) {
+    return new CSCMatrix(breeze.linalg.CSCMatrix.zeros(rows, columns, initialNonZeros, TAG, ZERO));
+  }
+
+  /**
+   * Creates a dense matrix by horizontal concatenation of vectors.
+   * All vectors should be instances of {@link DenseVector} and have the same length.
+   * @param vectors list of concatenating vectors
+   * @return a generated matrix
+   */
+  @Override
+  public DenseMatrix horzcatDense(final List<Vector> vectors) {
+    List<breeze.linalg.DenseVector<Double>> breezeVecList = Lists.transform(vectors,
+        new Function<Vector, breeze.linalg.DenseVector<Double>>() {
+          public breeze.linalg.DenseVector<Double> apply(final Vector vector) {
+            return ((DenseVector) vector).getBreezeVector();
+          }
+        });
+    return new DenseMatrix(
+        breeze.linalg.DenseVector.horzcat(JavaConversions.asScalaBuffer(breezeVecList), TAG, ZERO));
+  }
+
+  /**
+   * Creates a CSC matrix by horizontal concatenation of vectors.
+   * All vectors should be instances of {@link SparseVector} and have the same length.
+   * @param vectors list of concatenating vectors
+   * @return a generated matrix
+   */
+  @Override
+  public CSCMatrix horzcatSparse(final List<Vector> vectors) {
+    List<breeze.linalg.SparseVector<Double>> breezeVecList = Lists.transform(vectors,
+        new Function<Vector, breeze.linalg.SparseVector<Double>>() {
+          public breeze.linalg.SparseVector<Double> apply(final Vector vector) {
+            return ((SparseVector) vector).getBreezeVector();
+          }
+        });
+    return new CSCMatrix(
+        breeze.linalg.SparseVector.horzcat(JavaConversions.asScalaBuffer(breezeVecList), ZERO, TAG));
+  }
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultVectorFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultVectorFactory.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
 import breeze.storage.Zero;
 import breeze.storage.Zero$;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DenseMatrix.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DenseMatrix.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import breeze.linalg.NumericOps;
+import edu.snu.cay.common.math.linalg.Matrix;
+import edu.snu.cay.common.math.linalg.Vector;
+
+/**
+ * Matrix implementation based on breeze dense matrix.
+ * This class should be initialized by {@link edu.snu.cay.common.math.linalg.MatrixFactory}.
+ */
+public class DenseMatrix implements Matrix {
+
+  private final breeze.linalg.DenseMatrix<Double> breezeMatrix;
+
+  DenseMatrix(final breeze.linalg.DenseMatrix<Double> breezeMatrix) {
+    this.breezeMatrix = breezeMatrix;
+  }
+
+  breeze.linalg.DenseMatrix<Double> getBreezeMatrix() {
+    return breezeMatrix;
+  }
+
+  /**
+   * Returns the number of elements.
+   * @return number of elements
+   */
+  @Override
+  public int size() {
+    return breezeMatrix.size();
+  }
+
+  /**
+   * Returns the number of active elements.
+   * @return number of active elements
+   */
+  @Override
+  public int activeSize() {
+    return breezeMatrix.activeSize();
+  }
+
+  /**
+   * Returns true if the matrix is dense, false if sparse.
+   * @return true
+   */
+  @Override
+  public boolean isDense() {
+    return true;
+  }
+
+  /**
+   * Returns the number of rows.
+   * @return number of rows
+   */
+  @Override
+  public int getRows() {
+    return breezeMatrix.rows();
+  }
+
+  /**
+   * Returns the number of columns.
+   * @return number of columns
+   */
+  @Override
+  public int getColumns() {
+    return breezeMatrix.cols();
+  }
+
+  /**
+   * Returns a element specified by the row and column indices.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @return element specified by given indices
+   */
+  @Override
+  public double get(final int rowIndex, final int columnIndex) {
+    return breezeMatrix.apply(rowIndex, columnIndex);
+  }
+
+  /**
+   * Sets a matrix element.
+   * @param rowIndex an index in range [0, rows)
+   * @param columnIndex an index in range [0, columns)
+   * @param value given value
+   */
+  @Override
+  public void set(final int rowIndex, final int columnIndex, final double value) {
+    breezeMatrix.update(rowIndex, columnIndex, value);
+  }
+
+  /**
+   * Transpose this matrix.
+   * @return transposed copy of this matrix
+   */
+  @Override
+  public Matrix transpose() {
+    return new DenseMatrix((breeze.linalg.DenseMatrix<Double>) breezeMatrix.t(MatrixOps.T_D));
+  }
+
+  /**
+   * Returns a new matrix same as this one.
+   * @return copied new matrix
+   */
+  @Override
+  public Matrix copy() {
+    return new DenseMatrix(breezeMatrix.copy());
+  }
+
+  @Override
+  public String toString() {
+    return breezeMatrix.toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o instanceof DenseMatrix) {
+      return breezeMatrix.equals(((DenseMatrix) o).breezeMatrix);
+    }
+    if (o instanceof CSCMatrix) {
+      return breezeMatrix.equals(((CSCMatrix) o).getBreezeMatrix());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return breezeMatrix.hashCode();
+  }
+
+  /**
+   * Element-wise adds a matrix.
+   * @param matrix operand matrix
+   * @return new {@link DenseMatrix} with operation result
+   */
+  @Override
+  public Matrix add(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$plus(((DenseMatrix) matrix).breezeMatrix, MatrixOps.ADD_DD));
+    } else {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$plus(((CSCMatrix) matrix).getBreezeMatrix(), MatrixOps.ADD_DS));
+    }
+  }
+
+  /**
+   * Element-wise adds a matrix (in place).
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix addi(final Matrix matrix) {
+    if (matrix.isDense()) {
+      ((NumericOps) breezeMatrix).$plus$eq(((DenseMatrix) matrix).breezeMatrix, MatrixOps.ADDI_DD);
+    } else {
+      ((NumericOps) breezeMatrix).$plus$eq(((CSCMatrix) matrix).getBreezeMatrix(), MatrixOps.ADDI_DS);
+    }
+    return this;
+  }
+
+  /**
+   * Element-wise subtracts a matrix.
+   * @param matrix operand matrix
+   * @return new {@link DenseMatrix} with operation result
+   */
+  @Override
+  public Matrix sub(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$minus(((DenseMatrix) matrix).breezeMatrix, MatrixOps.SUB_DD));
+    } else {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$minus(((CSCMatrix) matrix).getBreezeMatrix(), MatrixOps.SUB_DS));
+    }
+  }
+
+  /**
+   * Element-wise subtracts a matrix (in place).
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix subi(final Matrix matrix) {
+    if (matrix.isDense()) {
+      ((NumericOps) breezeMatrix).$minus$eq(((DenseMatrix) matrix).breezeMatrix, MatrixOps.SUBI_DD);
+    } else {
+      ((NumericOps) breezeMatrix).$minus$eq(((CSCMatrix) matrix).getBreezeMatrix(), MatrixOps.SUBI_DS);
+    }
+    return this;
+  }
+
+  /**
+   * Multiplies a scalar to all elements.
+   * @param value operand scalar
+   * @return new {@link DenseMatrix} with operation result
+   */
+  @Override
+  public Matrix mul(final double value) {
+    return new DenseMatrix((breeze.linalg.DenseMatrix<Double>) breezeMatrix.$colon$times(value, MatrixOps.MUL_DT));
+  }
+
+  /**
+   * Multiplies a scalar to all elements (in place).
+   * @param value operand scalar
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix muli(final double value) {
+    ((NumericOps) breezeMatrix).$colon$times$eq(value, MatrixOps.MULI_DT);
+    return this;
+  }
+
+  /**
+   * Matrix-Matrix element-wise multiplication.
+   * Throws {@code UnsupportedOperationException} if the operand is {@link CSCMatrix}.
+   * @param matrix operand matrix
+   * @return new {@link DenseMatrix} operation result
+   */
+  @Override
+  public Matrix mul(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$colon$times(((DenseMatrix) matrix).breezeMatrix, MatrixOps.EMUL_DD));
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Matrix-Matrix element-wise multiplication (in place).
+   * Throws {@code UnsupportedOperationException} if the operand is {@link CSCMatrix}.
+   * @param matrix operand matrix
+   * @return this matrix with operation result
+   */
+  @Override
+  public Matrix muli(final Matrix matrix) {
+    if (matrix.isDense()) {
+      ((NumericOps) breezeMatrix).$colon$times$eq(((DenseMatrix) matrix).breezeMatrix, MatrixOps.EMULI_DD);
+      return this;
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Matrix-Vector multiplication.
+   * @param vector operand vector
+   * @return new {@link DenseVector} with operation result
+   */
+  @Override
+  public Vector mmul(final Vector vector) {
+    if (vector.isDense()) {
+      return new DenseVector((breeze.linalg.DenseVector<Double>)
+          breezeMatrix.$times(((DenseVector) vector).getBreezeVector(), MatrixOps.MUL_DMDV));
+    } else {
+      return new DenseVector((breeze.linalg.DenseVector<Double>)
+          breezeMatrix.$times(((SparseVector) vector).getBreezeVector(), MatrixOps.MUL_DMSV));
+    }
+  }
+
+  /**
+   * Matrix-Matrix multiplication.
+   * @param matrix operand matrix
+   * @return new {@link DenseMatrix} with operation result
+   */
+  @Override
+  public Matrix mmul(final Matrix matrix) {
+    if (matrix.isDense()) {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$times(((DenseMatrix) matrix).breezeMatrix, MatrixOps.MUL_DMDM));
+    } else {
+      return new DenseMatrix((breeze.linalg.DenseMatrix<Double>)
+          breezeMatrix.$times(((CSCMatrix) matrix).getBreezeMatrix(), MatrixOps.MUL_DMSM));
+    }
+  }
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DenseVector.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DenseVector.java
@@ -13,29 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
+import breeze.linalg.NumericOps;
 import breeze.linalg.package$;
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorEntry;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorEntry;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
 
 import java.util.Iterator;
 
 /**
- * Vector implementation based on breeze sparse vector.
- * This class should be initialized by {@link edu.snu.cay.common.math.vector.VectorFactory}.
+ * Vector implementation based on breeze dense vector.
+ * This class should be initialized by {@link edu.snu.cay.common.math.linalg.VectorFactory}.
  */
-public class SparseVector implements Vector {
+public class DenseVector implements Vector {
 
-  private final breeze.linalg.SparseVector<Double> breezeVector;
+  private final breeze.linalg.DenseVector<Double> breezeVector;
 
-  SparseVector(final breeze.linalg.SparseVector<Double> breezeVector) {
+  DenseVector(final breeze.linalg.DenseVector<Double> breezeVector) {
     this.breezeVector = breezeVector;
   }
 
-  breeze.linalg.SparseVector<Double> getBreezeVector() {
+  breeze.linalg.DenseVector<Double> getBreezeVector() {
     return breezeVector;
   }
 
@@ -49,7 +50,7 @@ public class SparseVector implements Vector {
   }
 
   /**
-   * Return the number of active(nonzero) elements.
+   * Return the number of active elements, which is same as {@code length()}.
    * @return number of active elements
    */
   @Override
@@ -59,11 +60,11 @@ public class SparseVector implements Vector {
 
   /**
    * Returns true if the vector is dense, false if sparse.
-   * @return false
+   * @return true
    */
   @Override
   public boolean isDense() {
-    return false;
+    return true;
   }
 
   /**
@@ -73,7 +74,7 @@ public class SparseVector implements Vector {
    */
   @Override
   public double get(final int index) {
-    return breezeVector.array().apply(index);
+    return breezeVector.apply(index);
   }
 
   /**
@@ -83,16 +84,16 @@ public class SparseVector implements Vector {
    */
   @Override
   public void set(final int index, final double value) {
-    breezeVector.array().update(index, value);
+    breezeVector.update(index, value);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (o instanceof SparseVector) {
-      return breezeVector.equals(((SparseVector) o).breezeVector);
-    }
     if (o instanceof DenseVector) {
-      return breezeVector.equals(((DenseVector) o).getBreezeVector());
+      return breezeVector.equals(((DenseVector) o).breezeVector);
+    }
+    if (o instanceof SparseVector) {
+      return breezeVector.equals(((SparseVector) o).getBreezeVector());
     }
     return false;
   }
@@ -107,13 +108,13 @@ public class SparseVector implements Vector {
    * @return copied new vector
    */
   @Override
-  public SparseVector copy() {
-    return new SparseVector(breezeVector.copy());
+  public DenseVector copy() {
+    return new DenseVector(breezeVector.copy());
   }
 
   @Override
   public Iterator<VectorEntry> iterator() {
-    return new SparseVectorIterator();
+    return new DenseVectorIterator();
   }
 
   @Override
@@ -123,82 +124,85 @@ public class SparseVector implements Vector {
 
   /**
    * Element-wise vector addition (in place).
-   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param vector operand vector
-   * @return operation result
+   * @return this vector with operation result
    */
   @Override
   public Vector addi(final Vector vector) {
-    throw new UnsupportedOperationException();
+    if (vector.isDense()) {
+      ((NumericOps)breezeVector).$colon$plus$eq(((DenseVector) vector).breezeVector, VectorOps.ADDI_DD);
+    } else {
+      ((NumericOps)breezeVector).$colon$plus$eq(((SparseVector) vector).getBreezeVector(), VectorOps.ADDI_DS);
+    }
+    return this;
   }
 
   /**
    * Element-wise vector addition.
-   * The result is {@link DenseVector} if the operand is {@link DenseVector},
-   * {@link SparseVector} otherwise.
    * @param vector operand vector
-   * @return new vector with operation result
+   * @return new {@link DenseVector} with operation result
    */
   @Override
   public Vector add(final Vector vector) {
     if (vector.isDense()) {
       return new DenseVector((breeze.linalg.DenseVector<Double>)
-          ((DenseVector) vector).getBreezeVector().$plus(breezeVector, VectorOps.ADD_DS));
+          breezeVector.$plus(((DenseVector) vector).breezeVector, VectorOps.ADD_DD));
     } else {
-      return new SparseVector((breeze.linalg.SparseVector<Double>)
-          breezeVector.$plus(((SparseVector) vector).breezeVector, VectorOps.ADD_SS));
+      return new DenseVector((breeze.linalg.DenseVector<Double>)
+          breezeVector.$plus(((SparseVector) vector).getBreezeVector(), VectorOps.ADD_DS));
     }
   }
 
   /**
    * Element-wise vector subtraction (in place).
-   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param vector operand vector
-   * @return operation result
+   * @return this vector with operation result
    */
   @Override
   public Vector subi(final Vector vector) {
-    throw new UnsupportedOperationException();
+    if (vector.isDense()) {
+      ((NumericOps)breezeVector).$colon$minus$eq(((DenseVector) vector).breezeVector, VectorOps.SUBI_DD);
+    } else {
+      ((NumericOps)breezeVector).$colon$minus$eq(((SparseVector) vector).getBreezeVector(), VectorOps.SUBI_DS);
+    }
+    return this;
   }
 
   /**
    * Element-wise vector subtraction.
-   * The result is {@link DenseVector} if the operand is {@link DenseVector},
-   * {@link SparseVector} otherwise.
    * @param vector operand vector
-   * @return new vector with operation result
+   * @return new {@link DenseVector} with operation result
    */
   @Override
   public Vector sub(final Vector vector) {
     if (vector.isDense()) {
       return new DenseVector((breeze.linalg.DenseVector<Double>)
-          ((DenseVector) vector).getBreezeVector().$minus(breezeVector, VectorOps.SUB_DS));
+          breezeVector.$minus(((DenseVector) vector).breezeVector, VectorOps.SUB_DD));
     } else {
-      return new SparseVector((breeze.linalg.SparseVector<Double>)
-          breezeVector.$minus(((SparseVector) vector).breezeVector, VectorOps.SUB_SS));
+      return new DenseVector((breeze.linalg.DenseVector<Double>)
+          breezeVector.$minus(((SparseVector) vector).getBreezeVector(), VectorOps.SUB_DS));
     }
   }
 
   /**
    * Multiplies a scala to all elements (in place).
-   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param value operand scala
-   * @return operation result
+   * @return this vector with operation result
    */
   @Override
   public Vector scalei(final double value) {
-    throw new UnsupportedOperationException();
+    ((NumericOps)breezeVector).$colon$times$eq(value, VectorOps.SCALEI_D);
+    return this;
   }
 
   /**
-   * Multiplies a scala to all elements (in place).
-   * Since breeze allocate new memory for this operation, this is actually not in-place.
+   * Multiplies a scala to all elements.
    * @param value operand scala
-   * @return new {@link SparseVector} with operation result
+   * @return new {@link DenseVector} with operation result
    */
   @Override
   public Vector scale(final double value) {
-    return new SparseVector((breeze.linalg.SparseVector<Double>) breezeVector.$colon$times(value, VectorOps.SCALE_S));
+    return new DenseVector((breeze.linalg.DenseVector<Double>) breezeVector.$colon$times(value, VectorOps.SCALE_D));
   }
 
   /**
@@ -210,9 +214,9 @@ public class SparseVector implements Vector {
   @Override
   public Vector axpy(final double value, final Vector vector) {
     if (vector.isDense()) {
-      throw new UnsupportedOperationException();
+      package$.MODULE$.axpy(value, ((DenseVector) vector).breezeVector, breezeVector, VectorOps.AXPY_DD);
     } else {
-      package$.MODULE$.axpy(value, ((SparseVector) vector).breezeVector, breezeVector, VectorOps.AXPY_SS);
+      package$.MODULE$.axpy(value, ((SparseVector) vector).getBreezeVector(), breezeVector, VectorOps.AXPY_DS);
     }
     return this;
   }
@@ -225,17 +229,17 @@ public class SparseVector implements Vector {
   @Override
   public double dot(final Vector vector) {
     if (vector.isDense()) {
-      return (double) ((DenseVector) vector).getBreezeVector().dot(breezeVector, VectorOps.DOT_DS);
+      return (double) breezeVector.dot(((DenseVector) vector).breezeVector, VectorOps.DOT_DD);
     } else {
-      return (double) breezeVector.dot(((SparseVector) vector).breezeVector, VectorOps.DOT_SS);
+      return (double) breezeVector.dot(((SparseVector) vector).getBreezeVector(), VectorOps.DOT_DS);
     }
   }
 
-  private class SparseVectorIterator implements Iterator<VectorEntry> {
+  private class DenseVectorIterator implements Iterator<VectorEntry> {
 
     private final Iterator<Tuple2<Object, Double>> iterator
         = JavaConversions.asJavaIterator(breezeVector.activeIterator());
-    private final SparseVectorEntry entry = new SparseVectorEntry();
+    private final DenseVectorEntry entry = new DenseVectorEntry();
 
     public boolean hasNext() {
       return iterator.hasNext();
@@ -251,7 +255,7 @@ public class SparseVector implements Vector {
     }
   }
 
-  private class SparseVectorEntry implements VectorEntry {
+  private class DenseVectorEntry implements VectorEntry {
 
     private Tuple2<Object, Double> cursor;
 

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/MatrixOps.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/MatrixOps.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import breeze.generic.UFunc;
+import breeze.linalg.support.CanTranspose;
+import breeze.math.Semiring;
+import breeze.math.Semiring$;
+import breeze.storage.Zero;
+import breeze.storage.Zero$;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+/**
+ * Class for breeze matrix operators.
+ */
+public final class MatrixOps {
+
+  private static final ClassTag TAG = ClassTag$.MODULE$.Double();
+  private static final Zero ZERO = Zero$.MODULE$.forClass(Double.TYPE);
+  private static final Semiring RING = Semiring$.MODULE$.semiringD();
+
+  private MatrixOps() {
+  }
+
+  // transpose operators
+  static final CanTranspose T_D = breeze.linalg.DenseMatrix.canTranspose();
+  static final CanTranspose T_S = breeze.linalg.CSCMatrix.canTranspose(TAG, ZERO, RING);
+
+  // add operators
+  static final UFunc.UImpl2 ADD_DD = breeze.linalg.DenseMatrix.op_DM_DM_Double_OpAdd();
+  static final UFunc.InPlaceImpl2 ADDI_DD = breeze.linalg.DenseMatrix.dm_dm_UpdateOp_Double_OpAdd();
+  static final UFunc.UImpl2 ADD_DS = breeze.linalg.CSCMatrix.dm_csc_OpAdd_Double();
+  static final UFunc.InPlaceImpl2 ADDI_DS = breeze.linalg.CSCMatrix.dm_csc_InPlace_OpAdd_Double();
+  static final UFunc.UImpl2 ADD_SS = breeze.linalg.CSCMatrix.csc_csc_OpAdd_Double();
+  static final UFunc.InPlaceImpl2 ADDI_SS = breeze.linalg.CSCMatrix.csc_csc_InPlace_Double_OpAdd();
+
+  // subtract operators
+  static final UFunc.UImpl2 SUB_DD = breeze.linalg.DenseMatrix.op_DM_DM_Double_OpSub();
+  static final UFunc.InPlaceImpl2 SUBI_DD = breeze.linalg.DenseMatrix.dm_dm_UpdateOp_Double_OpSub();
+  static final UFunc.UImpl2 SUB_DS = breeze.linalg.CSCMatrix.dm_csc_OpSub_Double();
+  static final UFunc.InPlaceImpl2 SUBI_DS = breeze.linalg.CSCMatrix.dm_csc_InPlace_OpSub_Double();
+  static final UFunc.UImpl2 SUB_SS = breeze.linalg.CSCMatrix.csc_csc_OpSub_Double();
+  static final UFunc.InPlaceImpl2 SUBI_SS = breeze.linalg.CSCMatrix.csc_csc_InPlace_Double_OpSub();
+
+  // scalar multiplication operatros
+  static final UFunc.UImpl2 MUL_DT = breeze.linalg.DenseMatrix.op_DM_S_Double_OpMulScalar();
+  static final UFunc.InPlaceImpl2 MULI_DT = breeze.linalg.DenseMatrix.dm_s_UpdateOp_Double_OpMulScalar();
+  static final UFunc.UImpl2 MUL_ST = breeze.linalg.CSCMatrix.implOps_CSCT_T_eq_CSCT_Double_OpMulScalar();
+  static final UFunc.InPlaceImpl2 MULI_ST = breeze.linalg.CSCMatrix.csc_T_InPlace_Double_OpMulScalar();
+
+  // vector multiplication operators
+  static final UFunc.UImpl2 MUL_DMDV = breeze.linalg.DenseMatrix$.MODULE$.implOpMulMatrix_DMD_DVD_eq_DVD();
+  static final UFunc.UImpl2 MUL_DMSV = breeze.linalg.SparseVector.implOpMulMatrix_DM_SV_eq_DV_Double();
+  static final UFunc.UImpl2 MUL_SMDV = breeze.linalg.CSCMatrix.canMulM_DV_Double();
+  static final UFunc.UImpl2 MUL_SMSV = breeze.linalg.CSCMatrix.canMulM_SV_Double();
+
+  // matrix multiplication operators
+  static final UFunc.UImpl2 MUL_DMDM = breeze.linalg.DenseMatrix$.MODULE$.implOpMulMatrix_DMD_DMD_eq_DMD();
+  static final UFunc.UImpl2 MUL_DMSM = breeze.linalg.CSCMatrix.canMulDM_M_Double();
+  static final UFunc.UImpl2 MUL_SMDM = breeze.linalg.CSCMatrix.canMulM_DM_Double();
+  static final UFunc.UImpl2 MUL_SMSM = breeze.linalg.CSCMatrix.canMulM_M_Double();
+
+  // matrix element-wise multiplication operators
+  static final UFunc.UImpl2 EMUL_DD = breeze.linalg.DenseMatrix.op_DM_DM_Double_OpMulScalar();
+  static final UFunc.InPlaceImpl2 EMULI_DD = breeze.linalg.DenseMatrix.dm_dm_UpdateOp_Double_OpMulScalar();
+  static final UFunc.UImpl2 EMUL_SS = breeze.linalg.CSCMatrix.csc_csc_OpMulScalar_Double();
+  static final UFunc.InPlaceImpl2 EMULI_SS = breeze.linalg.CSCMatrix.csc_csc_InPlace_Double_OpMulScalar();
+}

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/SparseVector.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/SparseVector.java
@@ -13,30 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
-import breeze.linalg.NumericOps;
 import breeze.linalg.package$;
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorEntry;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorEntry;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
 
 import java.util.Iterator;
 
 /**
- * Vector implementation based on breeze dense vector.
- * This class should be initialized by {@link edu.snu.cay.common.math.vector.VectorFactory}.
+ * Vector implementation based on breeze sparse vector.
+ * This class should be initialized by {@link edu.snu.cay.common.math.linalg.VectorFactory}.
  */
-public class DenseVector implements Vector {
+public class SparseVector implements Vector {
 
-  private final breeze.linalg.DenseVector<Double> breezeVector;
+  private final breeze.linalg.SparseVector<Double> breezeVector;
 
-  DenseVector(final breeze.linalg.DenseVector<Double> breezeVector) {
+  SparseVector(final breeze.linalg.SparseVector<Double> breezeVector) {
     this.breezeVector = breezeVector;
   }
 
-  breeze.linalg.DenseVector<Double> getBreezeVector() {
+  breeze.linalg.SparseVector<Double> getBreezeVector() {
     return breezeVector;
   }
 
@@ -50,7 +49,7 @@ public class DenseVector implements Vector {
   }
 
   /**
-   * Return the number of active elements, which is same as {@code length()}.
+   * Return the number of active(nonzero) elements.
    * @return number of active elements
    */
   @Override
@@ -60,11 +59,11 @@ public class DenseVector implements Vector {
 
   /**
    * Returns true if the vector is dense, false if sparse.
-   * @return true
+   * @return false
    */
   @Override
   public boolean isDense() {
-    return true;
+    return false;
   }
 
   /**
@@ -74,7 +73,7 @@ public class DenseVector implements Vector {
    */
   @Override
   public double get(final int index) {
-    return breezeVector.apply(index);
+    return breezeVector.array().apply(index);
   }
 
   /**
@@ -84,16 +83,16 @@ public class DenseVector implements Vector {
    */
   @Override
   public void set(final int index, final double value) {
-    breezeVector.update(index, value);
+    breezeVector.array().update(index, value);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (o instanceof DenseVector) {
-      return breezeVector.equals(((DenseVector) o).breezeVector);
-    }
     if (o instanceof SparseVector) {
-      return breezeVector.equals(((SparseVector) o).getBreezeVector());
+      return breezeVector.equals(((SparseVector) o).breezeVector);
+    }
+    if (o instanceof DenseVector) {
+      return breezeVector.equals(((DenseVector) o).getBreezeVector());
     }
     return false;
   }
@@ -108,13 +107,13 @@ public class DenseVector implements Vector {
    * @return copied new vector
    */
   @Override
-  public DenseVector copy() {
-    return new DenseVector(breezeVector.copy());
+  public SparseVector copy() {
+    return new SparseVector(breezeVector.copy());
   }
 
   @Override
   public Iterator<VectorEntry> iterator() {
-    return new DenseVectorIterator();
+    return new SparseVectorIterator();
   }
 
   @Override
@@ -124,85 +123,82 @@ public class DenseVector implements Vector {
 
   /**
    * Element-wise vector addition (in place).
+   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param vector operand vector
-   * @return this vector with operation result
+   * @return operation result
    */
   @Override
   public Vector addi(final Vector vector) {
-    if (vector.isDense()) {
-      ((NumericOps)breezeVector).$colon$plus$eq(((DenseVector) vector).breezeVector, VectorOps.ADDI_DD);
-    } else {
-      ((NumericOps)breezeVector).$colon$plus$eq(((SparseVector) vector).getBreezeVector(), VectorOps.ADDI_DS);
-    }
-    return this;
+    throw new UnsupportedOperationException();
   }
 
   /**
    * Element-wise vector addition.
+   * The result is {@link DenseVector} if the operand is {@link DenseVector},
+   * {@link SparseVector} otherwise.
    * @param vector operand vector
-   * @return new {@link DenseVector} with operation result
+   * @return new vector with operation result
    */
   @Override
   public Vector add(final Vector vector) {
     if (vector.isDense()) {
       return new DenseVector((breeze.linalg.DenseVector<Double>)
-          breezeVector.$plus(((DenseVector) vector).breezeVector, VectorOps.ADD_DD));
+          ((DenseVector) vector).getBreezeVector().$plus(breezeVector, VectorOps.ADD_DS));
     } else {
-      return new DenseVector((breeze.linalg.DenseVector<Double>)
-          breezeVector.$plus(((SparseVector) vector).getBreezeVector(), VectorOps.ADD_DS));
+      return new SparseVector((breeze.linalg.SparseVector<Double>)
+          breezeVector.$plus(((SparseVector) vector).breezeVector, VectorOps.ADD_SS));
     }
   }
 
   /**
    * Element-wise vector subtraction (in place).
+   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param vector operand vector
-   * @return this vector with operation result
+   * @return operation result
    */
   @Override
   public Vector subi(final Vector vector) {
-    if (vector.isDense()) {
-      ((NumericOps)breezeVector).$colon$minus$eq(((DenseVector) vector).breezeVector, VectorOps.SUBI_DD);
-    } else {
-      ((NumericOps)breezeVector).$colon$minus$eq(((SparseVector) vector).getBreezeVector(), VectorOps.SUBI_DS);
-    }
-    return this;
+    throw new UnsupportedOperationException();
   }
 
   /**
    * Element-wise vector subtraction.
+   * The result is {@link DenseVector} if the operand is {@link DenseVector},
+   * {@link SparseVector} otherwise.
    * @param vector operand vector
-   * @return new {@link DenseVector} with operation result
+   * @return new vector with operation result
    */
   @Override
   public Vector sub(final Vector vector) {
     if (vector.isDense()) {
       return new DenseVector((breeze.linalg.DenseVector<Double>)
-          breezeVector.$minus(((DenseVector) vector).breezeVector, VectorOps.SUB_DD));
+          ((DenseVector) vector).getBreezeVector().$minus(breezeVector, VectorOps.SUB_DS));
     } else {
-      return new DenseVector((breeze.linalg.DenseVector<Double>)
-          breezeVector.$minus(((SparseVector) vector).getBreezeVector(), VectorOps.SUB_DS));
+      return new SparseVector((breeze.linalg.SparseVector<Double>)
+          breezeVector.$minus(((SparseVector) vector).breezeVector, VectorOps.SUB_SS));
     }
   }
 
   /**
    * Multiplies a scala to all elements (in place).
+   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param value operand scala
-   * @return this vector with operation result
+   * @return operation result
    */
   @Override
   public Vector scalei(final double value) {
-    ((NumericOps)breezeVector).$colon$times$eq(value, VectorOps.SCALEI_D);
-    return this;
+    throw new UnsupportedOperationException();
   }
 
   /**
-   * Multiplies a scala to all elements.
+   * Multiplies a scala to all elements (in place).
+   * Since breeze allocate new memory for this operation, this is actually not in-place.
    * @param value operand scala
-   * @return new {@link DenseVector} with operation result
+   * @return new {@link SparseVector} with operation result
    */
   @Override
   public Vector scale(final double value) {
-    return new DenseVector((breeze.linalg.DenseVector<Double>) breezeVector.$colon$times(value, VectorOps.SCALE_D));
+    return new SparseVector((breeze.linalg.SparseVector<Double>) breezeVector.$colon$times(value, VectorOps.SCALE_S));
   }
 
   /**
@@ -214,9 +210,9 @@ public class DenseVector implements Vector {
   @Override
   public Vector axpy(final double value, final Vector vector) {
     if (vector.isDense()) {
-      package$.MODULE$.axpy(value, ((DenseVector) vector).breezeVector, breezeVector, VectorOps.AXPY_DD);
+      throw new UnsupportedOperationException();
     } else {
-      package$.MODULE$.axpy(value, ((SparseVector) vector).getBreezeVector(), breezeVector, VectorOps.AXPY_DS);
+      package$.MODULE$.axpy(value, ((SparseVector) vector).breezeVector, breezeVector, VectorOps.AXPY_SS);
     }
     return this;
   }
@@ -229,17 +225,17 @@ public class DenseVector implements Vector {
   @Override
   public double dot(final Vector vector) {
     if (vector.isDense()) {
-      return (double) breezeVector.dot(((DenseVector) vector).breezeVector, VectorOps.DOT_DD);
+      return (double) ((DenseVector) vector).getBreezeVector().dot(breezeVector, VectorOps.DOT_DS);
     } else {
-      return (double) breezeVector.dot(((SparseVector) vector).getBreezeVector(), VectorOps.DOT_DS);
+      return (double) breezeVector.dot(((SparseVector) vector).breezeVector, VectorOps.DOT_SS);
     }
   }
 
-  private class DenseVectorIterator implements Iterator<VectorEntry> {
+  private class SparseVectorIterator implements Iterator<VectorEntry> {
 
     private final Iterator<Tuple2<Object, Double>> iterator
         = JavaConversions.asJavaIterator(breezeVector.activeIterator());
-    private final DenseVectorEntry entry = new DenseVectorEntry();
+    private final SparseVectorEntry entry = new SparseVectorEntry();
 
     public boolean hasNext() {
       return iterator.hasNext();
@@ -255,7 +251,7 @@ public class DenseVector implements Vector {
     }
   }
 
-  private class DenseVectorEntry implements VectorEntry {
+  private class SparseVectorEntry implements VectorEntry {
 
     private Tuple2<Object, Double> cursor;
 

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/VectorOps.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/VectorOps.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
 import breeze.generic.UFunc;
 import breeze.linalg.SparseVector;

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/package-info.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Common vector classes.
+ * Breeze linalg Java wrapper package.
  */
-package edu.snu.cay.common.math.vector;
+package edu.snu.cay.common.math.linalg.breeze;

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/package-info.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Breeze Java wrapper package.
+ * Common linalg classes.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg;

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/MatrixFactoryTest.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/MatrixFactoryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import edu.snu.cay.common.math.linalg.Matrix;
+import edu.snu.cay.common.math.linalg.MatrixFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This tests {@link DefaultMatrixFactory}.
+ */
+public final class MatrixFactoryTest {
+
+  private MatrixFactory matrixFactory;
+  private VectorFactory vectorFactory;
+
+  @Before
+  public void setUp() {
+    try {
+      matrixFactory = Tang.Factory.getTang().newInjector().getInstance(DefaultMatrixFactory.class);
+      vectorFactory = Tang.Factory.getTang().newInjector().getInstance(VectorFactory.class);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Tests {@link DefaultMatrixFactory} creates {@link DenseMatrix} as intended.
+   */
+  @Test
+  public void testDenseMatrix() {
+    final double[] value = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2};
+    final Vector vec1 = vectorFactory.newDenseVector(value);
+    final Vector vec2 = vectorFactory.newDenseVector(value);
+    final List<Vector> denseVectorList = new ArrayList<>();
+    denseVectorList.add(vec1);
+    denseVectorList.add(vec2);
+
+    final Matrix mat1 = matrixFactory.createDenseZeros(3, 4);
+    final Matrix mat2 = matrixFactory.createDense(3, 4, value);
+    final Matrix mat3 = matrixFactory.createDense(12, 2, ArrayUtils.addAll(value, value));
+
+    assertEquals(mat1.size(), 12);
+    assertEquals(mat2.size(), 12);
+    assertEquals(mat3.size(), 24);
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 4; j++) {
+        assertEquals(mat1.get(i, j), 0.0, 0.0);
+        assertEquals(mat2.get(i, j), value[i + j * 3], 0.0);
+      }
+    }
+
+    assertEquals(matrixFactory.horzcatDense(denseVectorList), mat3);
+  }
+
+  /**
+   * Tests {@link DefaultMatrixFactory} creates {@link CSCMatrix} as intended.
+   */
+  @Test
+  public void testCSCMatrix() {
+    final int[][] index = {{0, 2, 4, 6}, {1, 2, 3, 4, 5}, {3, 5, 7}};
+    final double[][] value = {{0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7, 0.8, 0.9}, {1.0, 1.1, 1.2}};
+    final Vector vec1 = vectorFactory.newSparseVector(index[0], value[0], 10);
+    final Vector vec2 = vectorFactory.newSparseVector(index[1], value[1], 10);
+    final Vector vec3 = vectorFactory.newSparseVector(index[2], value[2], 10);
+    final List<Vector> sparseVectorList = new ArrayList<>();
+    sparseVectorList.add(vec1);
+    sparseVectorList.add(vec2);
+    sparseVectorList.add(vec3);
+
+    final Matrix mat1 = matrixFactory.createCSCZeros(10, 3, 0);
+    final Matrix mat2 = matrixFactory.horzcatSparse(sparseVectorList);
+
+    assertEquals(mat1.size(), 30);
+    assertEquals(mat2.size(), 30);
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < index[i].length; j++) {
+        assertEquals(mat2.get(index[i][j], i), value[i][j], 0.0);
+      }
+    }
+  }
+}

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/MatrixOpsTest.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/MatrixOpsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.common.math.linalg.breeze;
+
+import edu.snu.cay.common.math.linalg.Matrix;
+import edu.snu.cay.common.math.linalg.MatrixFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This tests matrix operations.
+ */
+public final class MatrixOpsTest {
+
+  private MatrixFactory matrixFactory;
+  private VectorFactory vectorFactory;
+
+  @Before
+  public void setUp() {
+    try {
+      matrixFactory = Tang.Factory.getTang().newInjector().getInstance(MatrixFactory.class);
+      vectorFactory = Tang.Factory.getTang().newInjector().getInstance(VectorFactory.class);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Tests dense matrix operations work well as intended.
+   */
+  @Test
+  public void testDenseMatrix() {
+    final double[] value1 = {0.1, 0.2, 0.3};
+    final double[] value2 = {0.4, 0.5, 0.6};
+    final double[] value3 = {1.0, 2.0};
+    final double[] value4 = {-1.0, -2.0};
+    final Vector vec1 = vectorFactory.newDenseVector(value1);
+    final Vector vec2 = vectorFactory.newDenseVector(value2);
+    final Vector vec3 = vectorFactory.newDenseVector(value3);
+    final Vector vec4 = vectorFactory.newDenseVector(value4);
+    final Vector vec5 = vectorFactory.newSparseVector(new int[]{0, 1}, value3, 2);
+    final List<Vector> denseVectorList1 = new ArrayList<>();
+    denseVectorList1.add(vec1);
+    denseVectorList1.add(vec2);
+    final List<Vector> denseVectorList2 = new ArrayList<>();
+    denseVectorList2.add(vec3);
+    denseVectorList2.add(vec4);
+    final List<Vector> denseVectorList3 = new ArrayList();
+    denseVectorList3.add(vec1.scale(value3[0]).add(vec2.scale(value3[1])));
+    denseVectorList3.add(vec1.scale(value4[0]).add(vec2.scale(value4[1])));
+
+    final Matrix mat1 = matrixFactory.createDenseZeros(3, 2);
+    final Matrix mat2 = matrixFactory.horzcatDense(denseVectorList1);
+    final Matrix mat3 = matrixFactory.horzcatDense(denseVectorList2);
+
+    assertEquals(mat1.add(mat2), mat2);
+    assertEquals(mat1.sub(mat2), mat2.mul(-1.0));
+    mat1.addi(mat2).muli(2.0).subi(mat2).muli(mat2);
+    assertEquals(mat2.mul(mat2), mat1);
+
+    assertEquals(mat2.mmul(mat3), matrixFactory.horzcatDense(denseVectorList3));
+    assertEquals(mat2.mmul(vec3), vec1.scale(vec3.get(0)).add(vec2.scale(vec3.get(1))));
+    assertEquals(mat2.mmul(vec5), mat2.mmul(vec3));
+  }
+
+
+  /**
+   * Tests CSC matrix operations work well as intended.
+   */
+  @Test
+  public void testCSCMatrix() {
+    final int[][] index1 = {{0, 2, 4, 6}, {1, 2, 3, 4, 5}};
+    final double[][] value1 = {{0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7, 0.8, 0.9}};
+    final int[][] index2 = {{0, 1}, {1}, {0, 1}};
+    final double[][] value2 = {{2.0, 1.0}, {0.5}, {-1.0, 0.0}};
+    final Vector vec1 = vectorFactory.newSparseVector(index1[0], value1[0], 7);
+    final Vector vec2 = vectorFactory.newSparseVector(index1[1], value1[1], 7);
+    final Vector vec3 = vectorFactory.newSparseVector(index2[0], value2[0], 2);
+    final Vector vec4 = vectorFactory.newSparseVector(index2[1], value2[1], 2);
+    final Vector vec5 = vectorFactory.newSparseVector(index2[2], value2[2], 2);
+    final Vector vec6 = vectorFactory.newDenseVector(value2[0]);
+    final List<Vector> sparseVectorList1 = new ArrayList<>();
+    sparseVectorList1.add(vec1);
+    sparseVectorList1.add(vec2);
+    final List<Vector> sparseVectorList2 = new ArrayList<>();
+    sparseVectorList2.add(vec3);
+    sparseVectorList2.add(vec4);
+    sparseVectorList2.add(vec5);
+
+    final Matrix mat1 = matrixFactory.createCSCZeros(7, 2, 0);
+    final Matrix mat2 = matrixFactory.horzcatSparse(sparseVectorList1);
+    final Matrix mat3 = matrixFactory.horzcatSparse(sparseVectorList2);
+
+    assertEquals(mat1.add(mat2), mat2);
+    assertEquals(mat1.sub(mat2), mat2.mul(-1.0));
+    mat1.addi(mat2).muli(2.0).subi(mat2).muli(mat2);
+    assertEquals(mat2.mul(mat2), mat1);
+
+    final List<Vector> sparseVectorList3 = new ArrayList<>();
+    sparseVectorList3.add(vec1.scale(vec3.get(0)).add(vec2.scale(vec3.get(1))));
+    sparseVectorList3.add(vec1.scale(vec4.get(0)).add(vec2.scale(vec4.get(1))));
+    sparseVectorList3.add(vec1.scale(vec5.get(0)).add(vec2.scale(vec5.get(1))));
+
+    assertEquals(mat2.mmul(mat3), matrixFactory.horzcatSparse(sparseVectorList3));
+    assertEquals(mat2.mmul(vec3), vec1.scale(vec3.get(0)).add(vec2.scale(vec3.get(1))));
+    assertEquals(mat2.mmul(vec6), mat2.mmul(vec3));
+  }
+}

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorFactoryTest.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorFactoryTest.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
-import edu.snu.cay.common.math.vector.*;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorEntry;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Before;

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorOpsTest.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorOpsTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Before;

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/package-info.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Tests for java-wrapped breeze classes.
+ * Tests for breeze linalg Java wrapper classes.
  */
-package edu.snu.cay.common.math.vector.breeze;
+package edu.snu.cay.common.math.linalg.breeze;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/classification/LogisticRegMainCmpTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/classification/LogisticRegMainCmpTask.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.algorithms.classification;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.core.UserComputeTask;
 import edu.snu.cay.dolphin.core.WorkloadPartition;
 import edu.snu.cay.dolphin.examples.ml.data.LinearModel;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/classification/LogisticRegMainCtrlTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/classification/LogisticRegMainCtrlTask.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.algorithms.classification;
 
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.common.param.Parameters.Iterations;
 import edu.snu.cay.dolphin.core.UserControllerTask;
 import edu.snu.cay.dolphin.examples.ml.converge.LinearModelConvCond;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/regression/LinearRegMainCmpTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/regression/LinearRegMainCmpTask.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.algorithms.regression;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.data.RowDataType;
 import edu.snu.cay.dolphin.examples.ml.data.LinearModel;
 import edu.snu.cay.dolphin.core.UserComputeTask;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/regression/LinearRegMainCtrlTask.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/algorithms/regression/LinearRegMainCtrlTask.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.algorithms.regression;
 
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.common.param.Parameters.Iterations;
 import edu.snu.cay.dolphin.examples.ml.data.LinearModel;
 import edu.snu.cay.dolphin.examples.ml.parameters.Dimension;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/converge/LinearModelConvEuclidean.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/converge/LinearModelConvEuclidean.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.converge;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.data.LinearModel;
 import edu.snu.cay.dolphin.examples.ml.parameters.ConvergenceThreshold;
 import org.apache.reef.tang.annotations.Parameter;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/ClassificationDenseDataParser.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/ClassificationDenseDataParser.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.core.ParseException;
 import edu.snu.cay.dolphin.core.DataParser;
 import edu.snu.cay.dolphin.examples.ml.parameters.Dimension;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/ClassificationSparseDataParser.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/ClassificationSparseDataParser.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.core.DataParser;
 import edu.snu.cay.dolphin.core.ParseException;
 import edu.snu.cay.dolphin.examples.ml.parameters.Dimension;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/LinearModel.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/LinearModel.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorEntry;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorEntry;
 
 public final class LinearModel implements Model {
   private Vector parameters;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/Model.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/Model.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.io.Serializable;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/RegressionDataParser.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/RegressionDataParser.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.core.ParseException;
 import edu.snu.cay.dolphin.examples.ml.parameters.Dimension;
 import edu.snu.cay.dolphin.core.DataParser;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/Row.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/data/Row.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.data;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 
 public final class Row {
   private final double output;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/HingeLoss.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/HingeLoss.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.loss;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 
 import javax.inject.Inject;
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/LogisticLoss.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/LogisticLoss.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.loss;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 
 import javax.inject.Inject;
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/Loss.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/Loss.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.loss;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/SquareLoss.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/loss/SquareLoss.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.loss;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 
 import javax.inject.Inject;
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/regularization/L2Regularization.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/regularization/L2Regularization.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.regularization;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.parameters.Lambda;
 import edu.snu.cay.dolphin.examples.ml.data.Model;
 import org.apache.reef.tang.annotations.Parameter;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/regularization/Regularization.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/regularization/Regularization.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.regularization;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.data.Model;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/DenseRowCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/DenseRowCodec.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.data.Row;
 import org.apache.reef.io.network.impl.StreamingCodec;
 import org.apache.reef.io.serialization.Codec;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/DenseVectorCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/DenseVectorCodec.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import org.apache.reef.io.network.impl.StreamingCodec;
 import org.apache.reef.io.serialization.Codec;
 

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/LinearRegSummaryCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/LinearRegSummaryCodec.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.examples.ml.data.LinearModel;
 import edu.snu.cay.dolphin.examples.ml.data.LinearRegSummary;
 import org.apache.reef.io.serialization.Codec;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/SparseRowCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/SparseRowCodec.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.dolphin.examples.ml.data.Row;
 import org.apache.reef.io.network.impl.StreamingCodec;
 import org.apache.reef.io.serialization.Codec;

--- a/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/SparseVectorCodec.java
+++ b/dolphin/src/main/java/edu/snu/cay/dolphin/examples/ml/sub/SparseVectorCodec.java
@@ -15,9 +15,9 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorEntry;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorEntry;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import org.apache.reef.io.network.impl.StreamingCodec;
 import org.apache.reef.io.serialization.Codec;
 

--- a/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/DenseRowCodecTest.java
+++ b/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/DenseRowCodecTest.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.examples.ml.data.Row;
 import org.apache.mahout.common.RandomUtils;
 import org.apache.reef.tang.Injector;

--- a/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/SparseRowCodecTest.java
+++ b/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/SparseRowCodecTest.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.dolphin.examples.ml.data.Row;
 import org.apache.mahout.common.RandomUtils;
 import org.apache.reef.tang.Injector;

--- a/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/SparseVectorCodecTest.java
+++ b/dolphin/src/test/java/edu/snu/cay/dolphin/examples/ml/sub/SparseVectorCodecTest.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.cay.dolphin.examples.ml.sub;
 
-import edu.snu.cay.common.math.vector.Vector;
-import edu.snu.cay.common.math.vector.VectorFactory;
+import edu.snu.cay.common.math.linalg.Vector;
+import edu.snu.cay.common.math.linalg.VectorFactory;
 import org.apache.mahout.common.RandomUtils;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <mockito.version>1.10.19</mockito.version>
     <ojalgo.version>37.1</ojalgo.version>
     <breeze.version>0.12</breeze.version>
+    <guava.version>19.0</guava.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
   </properties>
 
@@ -161,6 +162,11 @@
         <groupId>org.scalanlp</groupId>
         <artifactId>breeze_2.10</artifactId>
         <version>${breeze.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Closes #330.
This PR introduces new wrapper classes for Breeze matrix.
Not all methods in `breeze.linalg.DenseMatrix` and `breeze.linalg.CSCMatrix` are implemented. We can add those methods later if needed.
Vector classes and matrix classes are in the same package, `linalg`. This is because they have to access each other to execute some operations (e.g. `Matrix.mmul(Vector)`).
