### PR TITLE
Add a LoggingConfig to Cay and change all .sh scripts to use it.

### DIFF
--- a/dolphin-async/bin/run_addinteger.sh
+++ b/dolphin-async/bin/run_addinteger.sh
@@ -18,7 +18,7 @@
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run.sh
+++ b/dolphin/bin/run.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_em.sh
+++ b/dolphin/bin/run_em.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_kmeans.sh
+++ b/dolphin/bin/run_kmeans.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_logistic.sh
+++ b/dolphin/bin/run_logistic.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_matmul.sh
+++ b/dolphin/bin/run_matmul.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_pagerank.sh
+++ b/dolphin/bin/run_pagerank.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_regression.sh
+++ b/dolphin/bin/run_regression.sh
@@ -20,7 +20,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/dolphin/bin/run_sleep.sh
+++ b/dolphin/bin/run_sleep.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/services/elastic-memory/bin/run_simple.sh
+++ b/services/elastic-memory/bin/run_simple.sh
@@ -16,7 +16,7 @@
 # RUNTIME
 SELF_JAR=`echo ../target/elastic-memory-*-SNAPSHOT-shaded.jar`
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/services/ps/bin/run.sh
+++ b/services/ps/bin/run.sh
@@ -19,7 +19,7 @@
 # RUNTIME
 SELF_JAR=../target/ps-0.1-SNAPSHOT-shaded.jar
 
-LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'
 
 CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>tang</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.reef</groupId>
+      <artifactId>reef-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/utils/src/main/java/edu/snu/cay/utils/LoggingConfig.java
+++ b/utils/src/main/java/edu/snu/cay/utils/LoggingConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.utils;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+/**
+ * Wrapper for logging config.
+ */
+public final class LoggingConfig {
+
+  public LoggingConfig() throws IOException {
+    LogManager.getLogManager().readConfiguration(
+        Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("edu/snu/cay/utils/logging.properties"));
+  }
+}

--- a/utils/src/main/resources/edu/snu/cay/utils/logging.properties
+++ b/utils/src/main/resources/edu/snu/cay/utils/logging.properties
@@ -1,0 +1,80 @@
+# Copyright (C) 2016 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Properties file which configures the operation of the JDK
+# logging facility.
+# Heavily borrowed from REEF's logging.properties, and depends on REEF's ThreadLogFormatter.
+# For Cay developers, changing this configuration within Cay is much easier than changing REEF's configuration.
+
+# This config file should be redirected via the LoggingConfig class,
+# to ensure that it affects logs in all processes, even on different containers and hosts.
+# >java -Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig
+
+# Make sure the updated logging.properties is available in the java classpath
+# (it might need to packaged into a jar)
+
+# Global logging properties.
+# ------------------------------------------
+# The set of handlers to be loaded upon startup.
+# Comma-separated list of class names.
+# (? LogManager docs say no comma here, but JDK example has comma.)
+# handlers=java.utils.logging.FileHandler, java.utils.logging.ConsoleHandler
+handlers=java.util.logging.ConsoleHandler
+
+# java.util.logging.SimpleFormatter.format=%1$tF %1$tT,%1$tL %4$s %2$s - %5$s%6$s%n
+
+org.apache.reef.util.logging.ThreadLogFormatter.format=%1$tF %1$tT,%1$tL %4$s %2$s %7$s | %5$s%6$s%n
+org.apache.reef.util.logging.ThreadLogFormatter.dropPrefix=org.apache.,edu.snu.
+
+# Default global logging level.
+# Loggers and Handlers may override this level
+# Change to ALL for debugging
+.level=INFO
+
+# Loggers
+# ------------------------------------------
+# Loggers are usually attached to packages.
+# Here, the level for each package is specified.
+# The global level is used by default, so levels
+# specified here simply act as an override.
+
+# org.apache.reef.examples.level=FINEST
+# org.apache.reef.tang.level=INFO
+
+# Handlers
+# -----------------------------------------
+
+# --- ConsoleHandler ---
+# Override of global logging level
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=org.apache.reef.util.logging.ThreadLogFormatter
+
+# --- FileHandler ---
+# Override of global logging level
+java.util.logging.FileHandler.level=INFO
+
+# Naming style for the output file:
+# (The output file is placed in the directory
+# defined by the "user.home" System property.)
+java.util.logging.FileHandler.pattern=%h/reef.%u.log
+
+# Limiting size of output file in bytes:
+java.util.logging.FileHandler.limit=512000
+
+# Number of output files to cycle through, by appending an
+# integer to the base file name:
+java.util.logging.FileHandler.count=100
+
+# Style of output (Simple or XML):
+java.util.logging.FileHandler.formatter=org.apache.reef.util.logging.ThreadLogFormatter


### PR DESCRIPTION
Closes #335 

Add a LoggingConfig class and corresponding logging.properties file to Cay. This makes changing the Logger configuration, e.g., changing the logging level much easier. Without this change, you would have to change files in REEF to make this change.

Changed the LoggingConfig default to INFO. This makes more sense for _users_ of Cay, because the previous ALL is verbose enough to hinder performance.

Updated run*.sh scripts to point to Cay's LoggingConfig.
