### PR TITLE
[MINOR] Add NumKeys and StartKey to command line arguments for PS example

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/PartitionedPSExampleREEF.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/PartitionedPSExampleREEF.java
@@ -17,9 +17,7 @@ package edu.snu.cay.services.ps.examples.add;
 
 import edu.snu.cay.services.ps.ParameterServerConfigurationBuilder;
 import edu.snu.cay.services.ps.driver.impl.PartitionedParameterServerManager;
-import edu.snu.cay.services.ps.examples.add.parameters.JobTimeout;
-import edu.snu.cay.services.ps.examples.add.parameters.NumUpdates;
-import edu.snu.cay.services.ps.examples.add.parameters.NumWorkers;
+import edu.snu.cay.services.ps.examples.add.parameters.*;
 import edu.snu.cay.services.ps.server.partitioned.parameters.NumPartitions;
 import edu.snu.cay.services.ps.server.partitioned.parameters.QueueSize;
 import org.apache.reef.client.DriverConfiguration;
@@ -49,6 +47,8 @@ public final class PartitionedPSExampleREEF {
   private final long timeout;
   private final int numWorkers;
   private final int numUpdates;
+  private final int numKeys;
+  private final int startKey;
   private final int numPartitions;
   private final int queueSize;
 
@@ -56,11 +56,15 @@ public final class PartitionedPSExampleREEF {
   private PartitionedPSExampleREEF(@Parameter(JobTimeout.class) final long timeout,
                                    @Parameter(NumWorkers.class) final int numWorkers,
                                    @Parameter(NumUpdates.class) final int numUpdates,
+                                   @Parameter(NumKeys.class) final int numKeys,
+                                   @Parameter(StartKey.class) final int startKey,
                                    @Parameter(NumPartitions.class) final int numPartitions,
                                    @Parameter(QueueSize.class) final int queueSize) {
     this.timeout = timeout;
     this.numWorkers = numWorkers;
     this.numUpdates = numUpdates;
+    this.numKeys = numKeys;
+    this.startKey = startKey;
     this.numPartitions = numPartitions;
     this.queueSize = queueSize;
   }
@@ -85,6 +89,8 @@ public final class PartitionedPSExampleREEF {
     final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
         .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
+        .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+        .bindNamedParameter(StartKey.class, Integer.toString(startKey))
         .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
         .bindNamedParameter(QueueSize.class, Integer.toString(queueSize))
         .build();
@@ -120,6 +126,8 @@ public final class PartitionedPSExampleREEF {
     cl.registerShortNameOfClass(JobTimeout.class);
     cl.registerShortNameOfClass(NumWorkers.class);
     cl.registerShortNameOfClass(NumUpdates.class);
+    cl.registerShortNameOfClass(NumKeys.class);
+    cl.registerShortNameOfClass(StartKey.class);
     cl.registerShortNameOfClass(NumPartitions.class);
     cl.registerShortNameOfClass(QueueSize.class);
 

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/NumKeys.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/NumKeys.java
@@ -19,6 +19,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 @NamedParameter(doc = "Number of keys to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
-    default_value = "8")
+                default_value = "8",
+                short_name = "numKeys")
 public final class NumKeys implements Name<Integer> {
 }

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/NumUpdates.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/NumUpdates.java
@@ -18,6 +18,6 @@ package edu.snu.cay.services.ps.examples.add.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "Number of updates to apply per worker", default_value = "100", short_name = "numUpdates")
+@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
 public final class NumUpdates implements Name<Integer> {
 }

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/StartKey.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/parameters/StartKey.java
@@ -19,6 +19,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 @NamedParameter(doc = "Start key to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
-    default_value = "0")
+                default_value = "0",
+                short_name = "startKey")
 public final class StartKey implements Name<Integer> {
 }


### PR DESCRIPTION
This PR makes the parameters `NumKeys` and `StartKey` to be configurable via command line.
This also fixes a description error in the parameter class `NumUpdates`.
