### PR TITLE
[CAY-320] Remove processReply from PartitionWorker

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/ConcurrentParameterServerManager.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/ConcurrentParameterServerManager.java
@@ -21,8 +21,10 @@ import edu.snu.cay.services.ps.ns.PSMessageHandler;
 import edu.snu.cay.services.ps.server.concurrent.api.ParameterServer;
 import edu.snu.cay.services.ps.server.concurrent.impl.ServerSideMsgHandler;
 import edu.snu.cay.services.ps.server.concurrent.impl.ConcurrentParameterServer;
+import edu.snu.cay.services.ps.worker.AsyncWorkerHandler;
 import edu.snu.cay.services.ps.worker.api.ParameterWorker;
 import edu.snu.cay.services.ps.worker.concurrent.ConcurrentParameterWorker;
+import edu.snu.cay.services.ps.worker.concurrent.ConcurrentWorkerHandler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -59,6 +61,7 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
             .set(ServiceConfiguration.SERVICES, ConcurrentParameterWorker.class)
             .build())
         .bindImplementation(ParameterWorker.class, ConcurrentParameterWorker.class)
+        .bindImplementation(AsyncWorkerHandler.class, ConcurrentWorkerHandler.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/PartitionedParameterServerManager.java
@@ -24,9 +24,11 @@ import edu.snu.cay.services.ps.server.partitioned.PartitionedServerSideReplySend
 import edu.snu.cay.services.ps.server.partitioned.PartitionedServerSideReplySenderImpl;
 import edu.snu.cay.services.ps.server.partitioned.parameters.ServerNumPartitions;
 import edu.snu.cay.services.ps.server.partitioned.parameters.ServerQueueSize;
+import edu.snu.cay.services.ps.worker.AsyncWorkerHandler;
 import edu.snu.cay.services.ps.worker.api.ParameterWorker;
 import edu.snu.cay.services.ps.worker.partitioned.ContextStopHandler;
 import edu.snu.cay.services.ps.worker.partitioned.PartitionedParameterWorker;
+import edu.snu.cay.services.ps.worker.partitioned.PartitionedWorkerHandler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -75,6 +77,7 @@ public final class PartitionedParameterServerManager implements ParameterServerM
             .set(ServiceConfiguration.ON_CONTEXT_STOP, ContextStopHandler.class)
             .build())
         .bindImplementation(ParameterWorker.class, PartitionedParameterWorker.class)
+        .bindImplementation(AsyncWorkerHandler.class, PartitionedWorkerHandler.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/AsyncWorkerHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/AsyncWorkerHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.services.ps.worker;
+
+/**
+ * Process a pull reply message received from the server.
+ * This is an internal interface, to be used to connect the {@link WorkerSideMsgHandler}
+ * to a {@link edu.snu.cay.services.ps.worker.api.ParameterWorker}.
+ */
+public interface AsyncWorkerHandler<K, V> {
+  /**
+   * Reply to the worker with a {@code value} that was previously requested by {@code pull}.
+   * @param key key object representing what was sent
+   * @param value value sent from the server
+   */
+  void processReply(K key, V value);
+}

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/WorkerSideMsgHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/WorkerSideMsgHandler.java
@@ -19,7 +19,6 @@ import edu.snu.cay.services.ps.ParameterServerParameters.KeyCodecName;
 import edu.snu.cay.services.ps.ParameterServerParameters.ValueCodecName;
 import edu.snu.cay.services.ps.avro.AvroParameterServerMsg;
 import edu.snu.cay.services.ps.avro.ReplyMsg;
-import edu.snu.cay.services.ps.worker.api.ParameterWorker;
 import edu.snu.cay.utils.SingleMessageExtractor;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.network.Message;
@@ -38,9 +37,9 @@ public final class WorkerSideMsgHandler<K, P, V> implements EventHandler<Message
   private static final Logger LOG = Logger.getLogger(WorkerSideMsgHandler.class.getName());
 
   /**
-   * This evaluator's worker that is expecting Parameter Server messages.
+   * This evaluator's asynchronous handler that is expecting Parameter Server pull message results.
    */
-  private final ParameterWorker<K, P, V> parameterWorker;
+  private final AsyncWorkerHandler<K, V> asyncWorkerHandler;
 
   /**
    * Codec for decoding PS keys.
@@ -53,16 +52,16 @@ public final class WorkerSideMsgHandler<K, P, V> implements EventHandler<Message
   private final Codec<V> valueCodec;
 
   @Inject
-  private WorkerSideMsgHandler(final ParameterWorker<K, P, V> parameterWorker,
+  private WorkerSideMsgHandler(final AsyncWorkerHandler<K, V> asyncWorkerHandler,
                                @Parameter(KeyCodecName.class) final Codec<K> keyCodec,
                                @Parameter(ValueCodecName.class) final Codec<V> valueCodec) {
-    this.parameterWorker = parameterWorker;
+    this.asyncWorkerHandler = asyncWorkerHandler;
     this.keyCodec = keyCodec;
     this.valueCodec = valueCodec;
   }
 
   /**
-   * Hand over values given from the server to {@link ParameterWorker}.
+   * Hand over values given from the server to {@link AsyncWorkerHandler}.
    * Throws an exception if messages of an unexpected type arrive.
    */
   @Override 
@@ -85,6 +84,6 @@ public final class WorkerSideMsgHandler<K, P, V> implements EventHandler<Message
   private void onReplyMsg(final ReplyMsg replyMsg) {
     final K key = keyCodec.decode(replyMsg.getKey().array());
     final V value = valueCodec.decode(replyMsg.getValue().array());
-    parameterWorker.processReply(key, value);
+    asyncWorkerHandler.processReply(key, value);
   }
 }

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/api/ParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/api/ParameterWorker.java
@@ -40,12 +40,5 @@ public interface ParameterWorker<K, P, V> {
    * @return value specified by the {@code key}, or {@code null} if something unexpected happens (see implementation)
    */
   V pull(K key);
-
-  /**
-   * Reply to the worker with a {@code value} that was previously requested by {@code pull}.
-   * @param key key object representing what was sent
-   * @param value value sent from the server
-   */
-  void processReply(K key, V value);
 }
 

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/concurrent/ConcurrentParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/concurrent/ConcurrentParameterWorker.java
@@ -118,9 +118,9 @@ public final class ConcurrentParameterWorker<K, P, V> implements ParameterWorker
   }
 
   /**
-   * {@inheritDoc}
+   * Process a pull reply message received from the server.
+   * Called by {@link ConcurrentWorkerHandler#processReply}.
    */
-  @Override
   public void processReply(final K key, final V value) {
     final ValueWrapper valueWrapper = keyToValueWrapper.remove(key);
     if (valueWrapper != null) {

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/concurrent/ConcurrentWorkerHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/concurrent/ConcurrentWorkerHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.services.ps.worker.concurrent;
+
+import edu.snu.cay.services.ps.worker.AsyncWorkerHandler;
+
+import javax.inject.Inject;
+
+public final class ConcurrentWorkerHandler<K, V> implements AsyncWorkerHandler<K, V> {
+  private final ConcurrentParameterWorker<K, ?, V> concurrentParameterWorker;
+
+  @Inject
+  private ConcurrentWorkerHandler(final ConcurrentParameterWorker<K, ?, V> concurrentParameterWorker) {
+    this.concurrentParameterWorker = concurrentParameterWorker;
+  }
+
+  @Override
+  public void processReply(final K key, final V value) {
+    concurrentParameterWorker.processReply(key, value);
+  }
+}

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -211,8 +211,8 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
   /**
    * Handles incoming pull replies, by setting the value of the future.
    * This will notify the Partition's (synchronous) CacheLoader method to continue.
+   * Called by {@link PartitionedWorkerHandler#processReply}.
    */
-  @Override
   public void processReply(final K key, final V value) {
     final PullFuture<V> future = pendingPulls.get(key);
     if (future != null) {

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/partitioned/PartitionedWorkerHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/partitioned/PartitionedWorkerHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.services.ps.worker.partitioned;
+
+import edu.snu.cay.services.ps.worker.AsyncWorkerHandler;
+
+import javax.inject.Inject;
+
+public final class PartitionedWorkerHandler<K, V> implements AsyncWorkerHandler<K, V> {
+  private final PartitionedParameterWorker<K, ?, V> partitionedParameterWorker;
+
+  @Inject
+  private PartitionedWorkerHandler(final PartitionedParameterWorker<K, ?, V> partitionedParameterWorker) {
+    this.partitionedParameterWorker = partitionedParameterWorker;
+  }
+
+  @Override
+  public void processReply(final K key, final V value) {
+    partitionedParameterWorker.processReply(key, value);
+  }
+}

--- a/services/ps/src/test/java/edu/snu/cay/services/ps/worker/ConcurrentParameterWorkerTest.java
+++ b/services/ps/src/test/java/edu/snu/cay/services/ps/worker/ConcurrentParameterWorkerTest.java
@@ -16,6 +16,7 @@
 package edu.snu.cay.services.ps.worker;
 
 import edu.snu.cay.services.ps.driver.impl.ServerId;
+import edu.snu.cay.services.ps.worker.concurrent.ConcurrentWorkerHandler;
 import edu.snu.cay.services.ps.worker.concurrent.WorkerSideMsgSender;
 import edu.snu.cay.services.ps.worker.concurrent.ConcurrentParameterWorker;
 import edu.snu.cay.utils.ThreadUtils;
@@ -44,6 +45,7 @@ public final class ConcurrentParameterWorkerTest {
   private static final String MSG_THREADS_NOT_FINISHED = "threads not finished (possible deadlock or infinite loop)";
   private static final String MSG_RESULT_ASSERTION = "threads received null";
   private ConcurrentParameterWorker<Integer, Integer, Integer> worker;
+  private ConcurrentWorkerHandler<Integer, Integer> handler;
 
   @Before
   public void setup() throws InjectionException {
@@ -61,7 +63,7 @@ public final class ConcurrentParameterWorkerTest {
             try {
               // simulate slow network by purposely sleeping for 5 seconds
               Thread.sleep(5000);
-              worker.processReply(KEY, 1);
+              handler.processReply(KEY, 1);
             } catch (final InterruptedException e) {
               throw new RuntimeException(e);
             }
@@ -75,6 +77,7 @@ public final class ConcurrentParameterWorkerTest {
 
     injector.bindVolatileInstance(WorkerSideMsgSender.class, mockSender);
     worker = injector.getInstance(ConcurrentParameterWorker.class);
+    handler = injector.getInstance(ConcurrentWorkerHandler.class);
   }
 
   /**


### PR DESCRIPTION
Remove processReply from user-facing PartitionWorker by introducing AsyncWorkerHandler. AsyncWorkerHandler is implemented by Concurrent and Partitioned Workers; it is only meant to be used internally.

Closes #320 
