### PR TITLE
[CAY-383] Make EvaluatorManager.allocateEvaluators allow an empty list

### DIFF
--- a/services/evaluator-manager/src/test/java/edu/snu/cay/services/evalmanager/impl/HomogeneousEvalManagerTest.java
+++ b/services/evaluator-manager/src/test/java/edu/snu/cay/services/evalmanager/impl/HomogeneousEvalManagerTest.java
@@ -105,7 +105,7 @@ public final class HomogeneousEvalManagerTest {
         = getHandlersFromPlan(plan);
     finishedCounter = new CountDownLatch(evalNum);
 
-    evaluatorManager.allocateEvaluators(evalNum, handlers.getT1(), new ArrayList<EventHandler<ActiveContext>>());
+    evaluatorManager.allocateEvaluators(evalNum, handlers.getT1(), handlers.getT2());
 
     try {
       finishedCounter.await(TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Closes #383
