### PR TITLE
Implement multithreading for worker-side computation

### DIFF
--- a/common/src/main/java/edu/snu/cay/common/param/Parameters.java
+++ b/common/src/main/java/edu/snu/cay/common/param/Parameters.java
@@ -62,4 +62,10 @@ public final class Parameters {
                   short_name = "maxIter")
   public final class Iterations implements Name<Integer> {
   }
+
+  @NamedParameter(doc = "Number of computation threads for each worker",
+                  short_name = "numWorkerThreads",
+                  default_value = "2")
+  public final class NumWorkerThreads implements Name<Integer> {
+  }
 }

--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinLauncher.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinLauncher.java
@@ -120,6 +120,8 @@ public final class AsyncDolphinLauncher {
           .bindImplementation(Worker.class, asyncDolphinConfiguration.getWorkerClass())
           .bindNamedParameter(Iterations.class,
               Integer.toString(basicParameterInjector.getNamedInstance(Iterations.class)))
+          .bindNamedParameter(NumWorkerThreads.class,
+              Integer.toString(basicParameterInjector.getNamedInstance(NumWorkerThreads.class)))
           .build();
       final Configuration serializedWorkerConf = Tang.Factory.getTang().newConfigurationBuilder()
           .bindNamedParameter(SerializedWorkerConfiguration.class, confSerializer.toString(workerConf))
@@ -168,6 +170,7 @@ public final class AsyncDolphinLauncher {
     basicParameterClassList.add(InputDir.class);
     basicParameterClassList.add(OnLocal.class);
     basicParameterClassList.add(Splits.class);
+    basicParameterClassList.add(NumWorkerThreads.class);
     basicParameterClassList.add(Timeout.class);
     basicParameterClassList.add(LocalRuntimeMaxNumEvaluators.class);
     basicParameterClassList.add(Iterations.class);


### PR DESCRIPTION
This PR introduces multithreaded computation for the `dolphin-async` framework. A `Worker` implementation now corresponds to a single worker computation thread, and each worker evaluator creates several instances of `Worker`s. Input datasets are distributed evenly across worker threads via round-robin.

Closes #403.
