### PR TITLE
[CAY-444] Fine-grained partition of model vectors in MLR

### DIFF
--- a/common/src/main/java/edu/snu/cay/common/math/linalg/VectorFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/VectorFactory.java
@@ -18,6 +18,8 @@ package edu.snu.cay.common.math.linalg;
 import edu.snu.cay.common.math.linalg.breeze.DefaultVectorFactory;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
+import java.util.List;
+
 /**
  * Factory interface for {@link Vector}.
  */
@@ -60,4 +62,12 @@ public interface VectorFactory {
    * @return created vector
    */
   Vector createSparse(int[] index, double[] data, int length);
+
+  /**
+   * Creates a dense vector by concatenating several vectors.
+   * The values are deep copies; modifying the return vector does not affect the original vectors.
+   * @param vectors list of vectors to concatenate
+   * @return the vector created by concatenation
+   */
+  Vector concatDense(final List<Vector> vectors);
 }

--- a/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultVectorFactory.java
+++ b/common/src/main/java/edu/snu/cay/common/math/linalg/breeze/DefaultVectorFactory.java
@@ -19,11 +19,16 @@ import breeze.math.Semiring;
 import breeze.math.Semiring$;
 import breeze.storage.Zero;
 import breeze.storage.Zero$;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.math.linalg.VectorFactory;
+import scala.collection.JavaConversions;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import javax.inject.Inject;
+import java.util.List;
 
 /**
  * Factory class for breeze based vector.
@@ -94,5 +99,19 @@ public final class DefaultVectorFactory implements VectorFactory {
   public SparseVector createSparse(final int[] index, final double[] data, final int length) {
     assert (index.length == data.length);
     return new SparseVector(new breeze.linalg.SparseVector(index, data, length, ZERO));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public DenseVector concatDense(final List<Vector> vectors) {
+    final List<breeze.linalg.DenseVector<Double>> breezeVecList = Lists.transform(vectors,
+        new Function<Vector, breeze.linalg.DenseVector<Double>>() {
+          public breeze.linalg.DenseVector<Double> apply(final Vector vector) {
+            return ((DenseVector) vector).getBreezeVector();
+          }
+        });
+    return new DenseVector(
+        breeze.linalg.DenseVector.vertcat(JavaConversions.asScalaBuffer(breezeVecList), VectorOps.SET_DD, TAG, ZERO));
   }
 }

--- a/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorFactoryTest.java
+++ b/common/src/test/java/edu/snu/cay/common/math/linalg/breeze/VectorFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.cay.common.math.linalg.breeze;
 
+import com.google.common.collect.Lists;
 import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.math.linalg.VectorEntry;
 import edu.snu.cay.common.math.linalg.VectorFactory;
@@ -24,12 +25,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * This tests {@link DefaultVectorFactory}.
  */
 public final class VectorFactoryTest {
 
+  private static final double EPSILON = 0.01;
   private VectorFactory factory;
 
   @Before
@@ -59,6 +62,15 @@ public final class VectorFactoryTest {
       assertEquals(vec2.get(i), value[i], 0.0);
     }
     assertEquals(vec2, vec3);
+
+    final Vector vec4 = factory.concatDense(Lists.newArrayList(vec1, vec2));
+    for (int i = 0; i < 10; i++) {
+      assertEquals(vec1.get(i), vec4.get(i), EPSILON);
+      assertEquals(vec2.get(i), vec4.get(i + 10), EPSILON);
+    }
+
+    vec4.set(1, 10);
+    assertNotEquals(vec1.get(1), vec4.get(1), EPSILON);
   }
 
   /**

--- a/dolphin-async/src/main/java/edu/snu/cay/async/examples/mlr/MLRREEF.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/examples/mlr/MLRREEF.java
@@ -44,6 +44,7 @@ public final class MLRREEF {
         .addParameterClass(StepSize.class)
         .addParameterClass(Lambda.class)
         .addParameterClass(LossLogPeriod.class)
+        .addParameterClass(NumFeaturesPerPartition.class)
         .build());
   }
 
@@ -71,5 +72,10 @@ public final class MLRREEF {
                   short_name = "lossLogPeriod",
                   default_value = "0")
   final class LossLogPeriod implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "number of features for each model partition",
+                  short_name = "featuresPerPartition")
+  final class NumFeaturesPerPartition implements Name<Integer> {
   }
 }

--- a/dolphin-async/src/main/java/edu/snu/cay/async/examples/mlr/MLRUpdater.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/examples/mlr/MLRUpdater.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.cay.async.examples.mlr;
 
+import edu.snu.cay.async.examples.mlr.MLRREEF.NumFeaturesPerPartition;
 import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.services.ps.server.api.ParameterUpdater;
@@ -30,14 +31,14 @@ import java.util.Random;
  */
 final class MLRUpdater implements ParameterUpdater<Integer, Vector, Vector> {
 
-  private final int numFeatures;
+  private final int numFeaturesPerPartition;
   private final VectorFactory vectorFactory;
   private final Random random;
 
   @Inject
-  private MLRUpdater(@Parameter(MLRREEF.NumFeatures.class) final int numFeatures,
+  private MLRUpdater(@Parameter(NumFeaturesPerPartition.class) final int numFeaturesPerPartition,
                      final VectorFactory vectorFactory) {
-    this.numFeatures = numFeatures;
+    this.numFeaturesPerPartition = numFeaturesPerPartition;
     this.vectorFactory = vectorFactory;
     this.random = new Random();
   }
@@ -54,8 +55,8 @@ final class MLRUpdater implements ParameterUpdater<Integer, Vector, Vector> {
 
   @Override
   public Vector initValue(final Integer key) {
-    final double[] features = new double[numFeatures];
-    for (int featureIndex = 0; featureIndex < numFeatures; featureIndex++) {
+    final double[] features = new double[numFeaturesPerPartition];
+    for (int featureIndex = 0; featureIndex < numFeaturesPerPartition; featureIndex++) {
       features[featureIndex] = random.nextGaussian() * 0.01;
     }
     return vectorFactory.createDense(features);


### PR DESCRIPTION
This PR changes the MLR implementation so that model vectors that are stored at the parameter server can be split into multiple partitions and be stored separately. From now on, even if the model dimension is big, we can simply set the number of features per partition to be small enough for fine-grained management.

In order to implement this, I added yet another interface to `VectorFactory` that allows vector concatenation.

Closes #444.
