### PR TITLE
[MINOR] Log the number of worker threads

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncWorkerTask.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncWorkerTask.java
@@ -75,6 +75,7 @@ final class AsyncWorkerTask implements Task {
     final ExecutorService executorService = Executors.newFixedThreadPool(numWorkerThreads);
     final Future[] futures = new Future[numWorkerThreads];
 
+    LOG.log(Level.INFO, "Initializing {0} worker threads", numWorkerThreads);
     for (int index = 0; index < numWorkerThreads; index++) {
       // since a single injector only gives singleton instances,
       // we need to fork the given injector every time we spawn a new thread


### PR DESCRIPTION
This pull request changes `dolphin-async` to log the number of worker threads that are being used in each worker evaluator. This helps know the configuration through log files.
