### PR TITLE
[MINOR] Log synchronization status.

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/SynchronizationManager.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/SynchronizationManager.java
@@ -52,6 +52,8 @@ final class SynchronizationManager {
     this.aggregationMaster = aggregationMaster;
     this.numWorkers = dataLoadingService.getNumberOfPartitions();
     this.blockedWorkerIds = Collections.synchronizedSet(new HashSet<String>());
+
+    LOG.log(Level.FINE, "Total number of workers participating in the synchronization = {0}", numWorkers);
   }
 
   private void broadcastResponseMessages() {
@@ -68,6 +70,9 @@ final class SynchronizationManager {
     @Override
     public void onNext(final AggregationMessage aggregationMessage) {
       final String slaveId = aggregationMessage.getSourceId().toString();
+      LOG.log(Level.FINE, "Receive a synchronization message from {0}. {1} messages have been received out of {2}.",
+          new Object[]{slaveId, blockedWorkerIds.size(), numWorkers});
+
       if (blockedWorkerIds.contains(slaveId)) {
         LOG.log(Level.WARNING, "Multiple synchronization requests from {0}", slaveId);
       } else {


### PR DESCRIPTION
This pull request makes `SynchronizationManager` log its synchronization status.
This log is needed since there is a case when synchronization among workers does not succeed but users cannot know this. The problem case that I faced is the following. 
Suppose up to 50 evaluators are allocated simultaneously in a YARN cluster with the specified evaluator configuration like memory size. `SynchronizationManager` gets the number of workers from `DataLoadingService` through `getNumberOfPartitions()`. If the number of partitions suggested by DataSource is more than 50, `SynchronizationManager` cannot receive all sync messages from workers and waits them forever. Thus, the synchronization cannot be completed.
