### PR TITLE
[CAY-448] Make use of RoundRobinDataIdFactory in Dolphin-Async

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinDriver.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinDriver.java
@@ -20,7 +20,7 @@ import edu.snu.cay.common.aggregation.driver.AggregationManager;
 import edu.snu.cay.common.param.Parameters.NumWorkerThreads;
 import edu.snu.cay.services.em.driver.ElasticMemoryConfiguration;
 import edu.snu.cay.services.em.evaluator.api.DataIdFactory;
-import edu.snu.cay.services.em.evaluator.impl.BaseCounterDataIdFactory;
+import edu.snu.cay.services.em.evaluator.impl.RoundRobinDataIdFactory;
 import edu.snu.cay.services.evalmanager.api.EvaluatorManager;
 import edu.snu.cay.services.ps.common.partitioned.parameters.NumServers;
 import edu.snu.cay.services.ps.driver.ParameterServerDriver;
@@ -311,7 +311,7 @@ final class AsyncDolphinDriver {
               .set(TaskConfiguration.TASK, AsyncWorkerTask.class)
               .build();
           final Configuration emDataIdConf = Tang.Factory.getTang().newConfigurationBuilder()
-              .bindImplementation(DataIdFactory.class, BaseCounterDataIdFactory.class).build();
+              .bindImplementation(DataIdFactory.class, RoundRobinDataIdFactory.class).build();
 
           activeContext.submitTask(Configurations.merge(taskConf, workerConf, emDataIdConf));
         }

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/api/DataIdFactory.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/api/DataIdFactory.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.services.em.evaluator.api;
 
-import edu.snu.cay.services.em.evaluator.impl.BaseCounterDataIdFactory;
+import edu.snu.cay.services.em.evaluator.impl.RoundRobinDataIdFactory;
 import edu.snu.cay.services.em.exceptions.IdGenerationException;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
@@ -28,7 +28,7 @@ import java.util.List;
  * to avoid tedious communications between evaluators.
  * @param <T> type of data id
  */
-@DefaultImplementation(BaseCounterDataIdFactory.class)
+@DefaultImplementation(RoundRobinDataIdFactory.class)
 public interface DataIdFactory<T> {
   /**
    * Give a new data id.


### PR DESCRIPTION
It closes #448.

This PR has only a simple configuration change.

In #429, we introduced a `RoundRobinDataIdFactory`, which is a new implementation of `DataIdFactory`.
But still `BaseDataIdFactory`, an old `DataIdFactory is used in dolphin-async. (it's maybe what we just missed in #429.)

This PR has following changes.
- Makes dolphin-async use `RoundRobinDataIdFactory`. (`NMFREEF` will be affected by this change.)
- Changes the default implementation of `DataIdFactory` to `RoundRobinDataIdFactory`.
