### PR TITLE
[MINOR] Fix log that outputs the number of synchronization messages

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/SynchronizationManager.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/SynchronizationManager.java
@@ -70,14 +70,13 @@ final class SynchronizationManager {
     @Override
     public void onNext(final AggregationMessage aggregationMessage) {
       final String slaveId = aggregationMessage.getSourceId().toString();
-      LOG.log(Level.FINE, "Receive a synchronization message from {0}. {1} messages have been received out of {2}.",
-          new Object[]{slaveId, blockedWorkerIds.size(), numWorkers});
-
       if (blockedWorkerIds.contains(slaveId)) {
         LOG.log(Level.WARNING, "Multiple synchronization requests from {0}", slaveId);
       } else {
         blockedWorkerIds.add(slaveId);
       }
+      LOG.log(Level.FINE, "Receive a synchronization message from {0}. {1} messages have been received out of {2}.",
+          new Object[]{slaveId, blockedWorkerIds.size(), numWorkers});
 
       if (blockedWorkerIds.size() == numWorkers) {
         LOG.log(Level.INFO, "{0} workers are blocked. Sending response messages to awake them", numWorkers);


### PR DESCRIPTION
This pull request changes `SynchronizationManager` to output the number of synchronization messages received from workers including messages that have just arrived at that time.
