### PR TITLE
[MINOR] Add missing short_name parameter to the run_mlr.sh script

### DIFF
--- a/dolphin-async/bin/run_mlr.sh
+++ b/dolphin-async/bin/run_mlr.sh
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_mlr.sh -split 4 -numServers 2 -numPartitions 4 -numWorkerThreads 1 -local true -input sample_mlr -maxNumEvalLocal 7 -maxIter 20 -stepSize 0.1 -classes 10 -features 784 -batch 50 -lambda 0.005 -timeout 200000 -lossLogPeriod 5 -featuresPerPartition 392
-
+# ./run_mlr.sh -split 4 -numServers 2 -numPartitions 4 -numWorkerThreads 1 -local true -input sample_mlr -maxNumEvalLocal 7 -maxIter 20 -stepSize 0.1 -classes 10 -features 784 -featuresPerPartition 392 -batch 50 -lambda 0.005 -timeout 200000 -lossLogPeriod 5
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 
 LOGGING_CONFIG='-Djava.util.logging.config.class=edu.snu.cay.utils.LoggingConfig'


### PR DESCRIPTION
da74a2e5866c48c46225d0415c7153cd1e67b6b0  introduced `NumFeaturesPerPartition`, but the example command in `run_mlr.sh` script has not been updated yet. As a result, Running with the example command causes a failure due to the missing parameter.

This change updates the command, so users can just copy & paste the command from the script, without adding the short name parameter manually.
