### PR TITLE
[Minor] Add a timeout to Dynamic Partitioned PS test

### DIFF
--- a/services/ps/src/test/java/edu/snu/cay/services/ps/server/DynamicPartitionedParameterServerTest.java
+++ b/services/ps/src/test/java/edu/snu/cay/services/ps/server/DynamicPartitionedParameterServerTest.java
@@ -122,7 +122,7 @@ public final class DynamicPartitionedParameterServerTest {
    * Test the performance of {@link DynamicPartitionedParameterServer} by
    * running threads that push values to and pull values from the server, concurrently.
    */
-  @Test
+  @Test(timeout = 200000)
   public void testMultiThreadPushPull() throws InterruptedException {
     final int numPushThreads = 8;
     final int numPushes = 1000000;


### PR DESCRIPTION
`DynamicPartitionedParameterServerTest` never finishes when the PS fails to handle operations with exceptions. As the `DynamicPS` is based on EM, the tests can be affected by the changes in EM code. We've found that a bug in EM code can make the tests run forever.

This PR adds a timeout to the test, to wait with a bounded time.
