### PR TITLE
[CAY-486] Remove redundant hashing in dynamic PS server

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/HashBlockResolver.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/HashBlockResolver.java
@@ -15,12 +15,9 @@
  */
 package edu.snu.cay.services.em.evaluator.impl;
 
-import edu.snu.cay.services.em.common.parameters.KeyCodecName;
 import edu.snu.cay.services.em.common.parameters.NumTotalBlocks;
 import edu.snu.cay.services.em.evaluator.api.BlockResolver;
-import org.apache.hadoop.util.hash.MurmurHash;
 import org.apache.reef.io.network.util.Pair;
-import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -30,19 +27,16 @@ import java.util.Map;
  * Resolves the block using the hashed value of the key.
  */
 public final class HashBlockResolver<K> implements BlockResolver<K> {
-  private Codec keyCodec;
   private final int numTotalBlocks;
 
   @Inject
-  HashBlockResolver(@Parameter(KeyCodecName.class) final Codec keyCodec,
-                    @Parameter(NumTotalBlocks.class) final int numTotalBlocks) {
+  HashBlockResolver(@Parameter(NumTotalBlocks.class) final int numTotalBlocks) {
     this.numTotalBlocks = numTotalBlocks;
-    this.keyCodec = keyCodec;
   }
 
   @Override
   public int resolveBlock(final K dataKey) {
-    final int hashed = Math.abs(MurmurHash.getInstance().hash(keyCodec.encode(dataKey)));
+    final int hashed = Math.abs(dataKey.hashCode());
     return hashed % numTotalBlocks;
   }
 

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/server/partitioned/HashedKey.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/server/partitioned/HashedKey.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.services.ps.server.partitioned;
+
+/**
+ * A class containing key with its hash value.
+ * @param <K> a type of key
+ */
+public class HashedKey<K> {
+  private K key;
+  private final int hash;
+
+  public HashedKey(final K key, final int hash) {
+    this.key = key;
+    this.hash = hash;
+  }
+
+  public K getKey() {
+    return key;
+  }
+
+  public int getHash() {
+    return hash;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HashedKey<?> that = (HashedKey<?>) o;
+
+    return key.equals(that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+}


### PR DESCRIPTION
It is a part of #486.

The current implementation of dynamic PS calculates a hash value of the same key three times for a single operation.

It calculates hash when 1) receiving the msg, and 2) before enqueueing operation, and 3) and before choosing block in the MemoryStore.

I remove 2) and 3) case and reuse the hash value generated in 1).
It looks that 2) case is a kind of mistake, so it was simply fixed.
More importantly, to addressing 3) case, I added `HashedKey` class containing key(K) and its hash value (Integer). And by using `HashedKey` as a key for `MemoryStore<HashedKey<K>>`, now EM's `HashBlockResolver` does not perform hashing and just uses the hash key obtained when 1). (as @yunseong's suggestion, thanks!)

I've tested the performance with `DynamicPartitionedParameterServerTest` similar with #488.
The test performs 10M operations for each push/pull type with each 8 threads.
[Static]
23s
[Dynamic]
85s with master
78s with this PR
35s with #488
30s with #488 + this PR

This PR reduces the test time about 20%!, but the dynamic version is still 25% slower than static version.
I will keep exploring it.
