### PR TITLE
[CAY-494] NMF supports EM move operation

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/examples/nmf/NMFData.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/examples/nmf/NMFData.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.cay.async.examples.nmf;
 
+import edu.snu.cay.common.math.linalg.Vector;
 import org.apache.reef.io.network.util.Pair;
 
 import java.io.Serializable;
@@ -27,11 +28,14 @@ final class NMFData implements Serializable {
 
   private final int rowIndex;
   private final List<Pair<Integer, Double>> columns;
+  private final Vector vector;
 
   NMFData(final int rowIndex,
-          final List<Pair<Integer, Double>> columns) {
+          final List<Pair<Integer, Double>> columns,
+          final Vector vector) {
     this.rowIndex = rowIndex;
     this.columns = columns;
+    this.vector = vector;
   }
 
   int getRowIndex() {
@@ -41,4 +45,8 @@ final class NMFData implements Serializable {
   List<Pair<Integer, Double>> getColumns() {
     return columns;
   };
+
+  Vector getVector() {
+    return vector;
+  }
 }

--- a/dolphin-async/src/main/java/edu/snu/cay/async/examples/nmf/NMFDataParser.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/examples/nmf/NMFDataParser.java
@@ -39,10 +39,13 @@ import java.util.List;
  */
 final class NMFDataParser {
   private final DataSet<LongWritable, Text> dataSet;
+  private final NMFModelGenerator modelGenerator;
 
   @Inject
-  private NMFDataParser(final DataSet<LongWritable, Text> dataSet) {
+  private NMFDataParser(final DataSet<LongWritable, Text> dataSet,
+                        final NMFModelGenerator modelGenerator) {
     this.dataSet = dataSet;
+    this.modelGenerator = modelGenerator;
   }
 
   private List<Pair<Integer, Double>> parseColumns(final String columnsString) {
@@ -101,7 +104,7 @@ final class NMFDataParser {
         throw new RuntimeException("Failed to parse: invalid indices. It should be greater than zero");
       }
 
-      result.add(new NMFData(rowIndex, parseColumns(split[1].trim())));
+      result.add(new NMFData(rowIndex, parseColumns(split[1].trim()), modelGenerator.createRandomVector()));
     }
     return result;
   }


### PR DESCRIPTION
This pull request changes NMF to put row vector models into `NMFData` instances, which are stored in `MemoryStore`, in order to support EM move operation.
Saving a row vector model with its corresponding training data allows EM to move both models and training data to another worker, which enables the recipient worker to perform training process on the moved data.

Closes #494.
