### PR TITLE
[MINOR] Check validity of arguments when EM.add() is called

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/ElasticMemoryImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/ElasticMemoryImpl.java
@@ -41,10 +41,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @DriverSide
 @Private
 public final class ElasticMemoryImpl implements ElasticMemory {
+  private static final Logger LOG = Logger.getLogger(ElasticMemoryImpl.class.getName());
   private static final String MOVE = "move";
   private static final String APPLY_UPDATES = "apply_updates";
 
@@ -77,13 +80,24 @@ public final class ElasticMemoryImpl implements ElasticMemory {
   /**
    * Request for evaluators and remember passed callback.
    * Currently assumes that every request has same memory size and cores.
+   * Note that the requests are handled only when the arguments are positive.
    * TODO #188: Support heterogeneous evaluator requests
    */
   @Override
   public void add(final int number, final int megaBytes, final int cores,
                   final EventHandler<AllocatedEvaluator> evaluatorAllocatedHandler,
                   final List<EventHandler<ActiveContext>> contextActiveHandlerList) {
-    evaluatorManager.allocateEvaluators(number, evaluatorAllocatedHandler, contextActiveHandlerList);
+    if (number == 0) {
+      LOG.log(Level.WARNING, "Ignore the request for zero evaluator");
+    } else if (number < 0) {
+      throw new RuntimeException("The number of evaluators must be positive, but requested: " + number);
+    } else if (megaBytes <= 0) {
+      throw new RuntimeException("The capacity of evaluators must be positive, but requested: " + megaBytes);
+    } else if (cores <= 0) {
+      throw new RuntimeException("The CPU cores of evaluators must be positive, but requested: " + cores);
+    } else {
+      evaluatorManager.allocateEvaluators(number, evaluatorAllocatedHandler, contextActiveHandlerList);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds a sanity check for the arguments passed in EM.add(). The motivation was also from the testing with optimizer; When zero Evaluator is requested via EM.add(), then the resource request to EvaluatorManager was created, where a latch awaits until the callback is invoked. As a result, the optimization never finished.

`EM.add()` checks arguments as follows:
- Ignores and just returns if the number of evaluators is zero, which is possible result of optimization.
- Rejects the cases that have no point or cannot be achieved.
