### PR TITLE
[CAY-500] Fix bugs in move

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/singlekey/MemoryStoreImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/singlekey/MemoryStoreImpl.java
@@ -120,25 +120,18 @@ public final class MemoryStoreImpl<K> implements RemoteAccessibleMemoryStore<K> 
 
   @Override
   public void putBlock(final String dataType, final int blockId, final Map<K, Object> data) {
-    final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
-    if (null == blocks) {
-      // If this MemoryStore has never stored the data in this type.
-      // Then just create a block with the received data, and put it in the Map associating with the data type.
-      final Block block = new Block();
-      block.putAll(data);
-      final Map<Integer, Block> newBlocks = new HashMap<>();
-      newBlocks.put(blockId, block);
+    // If this MemoryStore has never stored the data in this type, initialize the blocks.
+    if (!typeToBlocks.containsKey(dataType)) {
+      initBlocks(dataType);
+    }
 
-      typeToBlocks.put(dataType, newBlocks);
-      LOG.log(Level.INFO, "The block {0} in type {1} has moved in.", new Object[]{blockId, dataType});
-    } else if (!blocks.containsKey(blockId)) {
-      // If the MemoryStore has the data in this type, but the block is not the exact same with the received one.
-      // Then just put the block.
+    final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
+    if (blocks.containsKey(blockId)) {
+      throw new RuntimeException("Block " + blockId + " already exists.");
+    } else {
       final Block block = new Block();
       block.putAll(data);
       blocks.put(blockId, block);
-    } else {
-      throw new RuntimeException("Block " + blockId + " already exists.");
     }
   }
 
@@ -150,7 +143,7 @@ public final class MemoryStoreImpl<K> implements RemoteAccessibleMemoryStore<K> 
       return Collections.emptyMap();
     }
 
-    final Block block = typeToBlocks.get(dataType).get(blockId);
+    final Block block = blocks.get(blockId);
     if (null == block) {
       LOG.log(Level.WARNING, "Block with id {0} does not exist.", blockId);
       return Collections.emptyMap();


### PR DESCRIPTION
This closes #500.

In `putBlock()`, the received blocks are stored after the initialization (which were not before).In `getBlock()`, requests for the data type that has not been observed are allowed, but leaves a `WARNING` log to inform users.
