### PR TITLE
[CAY-507] Add serializer option to Async-Dolphin

### DIFF
--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinConfiguration.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinConfiguration.java
@@ -15,6 +15,8 @@
  */
 package edu.snu.cay.async;
 
+import edu.snu.cay.services.em.serialize.JavaSerializer;
+import edu.snu.cay.services.em.serialize.Serializer;
 import edu.snu.cay.services.ps.server.api.ParameterUpdater;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.io.serialization.Codec;
@@ -39,19 +41,26 @@ public final class AsyncDolphinConfiguration {
   private final Class<? extends Codec> preValueCodecClass;
   private final Class<? extends Codec> valueCodecClass;
   private final List<Class<? extends Name<?>>> parameterClassList;
+  private final Class<? extends Serializer> workerSerializerClass;
+  private final Class<? extends Serializer> serverSerializerClass;
+
 
   private AsyncDolphinConfiguration(final Class<? extends Worker> workerClass,
                                     final Class<? extends ParameterUpdater> updaterClass,
                                     final Class<? extends Codec> keyCodecClass,
                                     final Class<? extends Codec> preValueCodecClass,
                                     final Class<? extends Codec> valueCodecClass,
-                                    final List<Class<? extends Name<?>>> parameterClassList) {
+                                    final List<Class<? extends Name<?>>> parameterClassList,
+                                    final Class<? extends Serializer> workerSerializerClass,
+                                    final Class<? extends Serializer> serverSerializerClass) {
     this.workerClass = workerClass;
     this.updaterClass = updaterClass;
     this.keyCodecClass = keyCodecClass;
     this.preValueCodecClass = preValueCodecClass;
     this.valueCodecClass = valueCodecClass;
     this.parameterClassList = parameterClassList;
+    this.workerSerializerClass = workerSerializerClass;
+    this.serverSerializerClass = serverSerializerClass;
   }
 
   public Class<? extends Worker> getWorkerClass() {
@@ -78,6 +87,15 @@ public final class AsyncDolphinConfiguration {
     return parameterClassList;
   }
 
+  public Class<? extends Serializer> getWorkerSerializerClass() {
+    return workerSerializerClass;
+  }
+
+  public Class<? extends Serializer> getServerSerializerClass() {
+    return serverSerializerClass;
+  }
+
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -89,6 +107,9 @@ public final class AsyncDolphinConfiguration {
     private Class<? extends Codec> preValueCodecClass = SerializableCodec.class;
     private Class<? extends Codec> valueCodecClass = SerializableCodec.class;
     private List<Class<? extends Name<?>>> parameterClassList = new LinkedList<>();
+    private Class<? extends Serializer> workerSerializerClass = JavaSerializer.class;
+    private Class<? extends Serializer> serverSerializerClass = JavaSerializer.class;
+
 
     public Builder setWorkerClass(final Class<? extends Worker> workerClass) {
       this.workerClass = workerClass;
@@ -120,6 +141,16 @@ public final class AsyncDolphinConfiguration {
       return this;
     }
 
+    public Builder setWorkerSerializerClass(final Class<? extends Serializer> workerSerializerClass) {
+      this.workerSerializerClass = workerSerializerClass;
+      return this;
+    }
+
+    public Builder setServerSerializerClass(final Class<? extends Serializer> serverSerializerClass) {
+      this.serverSerializerClass = serverSerializerClass;
+      return this;
+    }
+
     @Override
     public AsyncDolphinConfiguration build() {
       if (workerClass == null) {
@@ -131,7 +162,8 @@ public final class AsyncDolphinConfiguration {
       }
 
       return new AsyncDolphinConfiguration(workerClass, updaterClass,
-          keyCodecClass, preValueCodecClass, valueCodecClass, parameterClassList);
+          keyCodecClass, preValueCodecClass, valueCodecClass, parameterClassList,
+          workerSerializerClass, serverSerializerClass);
     }
   }
 }

--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinDriver.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinDriver.java
@@ -142,6 +142,16 @@ final class AsyncDolphinDriver {
   private final Configuration paramConf;
 
   /**
+   * Worker-side EM client configuration, that should be passed to worker EM contexts.
+   */
+  private final Configuration emWorkerClientConf;
+
+  /**
+   * Server-side EM client configuration, that should be passed to server EM contexts.
+   */
+  private final Configuration emServerClientConf;
+
+  /**
    * Queue of activeContext objects of the evaluators housing the parameter server.
    */
   private ConcurrentLinkedQueue<ActiveContext> serverContexts;
@@ -195,6 +205,10 @@ final class AsyncDolphinDriver {
                              final AggregationManager aggregationManager,
                              @Parameter(SerializedWorkerConfiguration.class) final String serializedWorkerConf,
                              @Parameter(SerializedParameterConfiguration.class) final String serializedParamConf,
+                             @Parameter(SerializedEMWorkerClientConfiguration.class)
+                                 final String serializedEMWorkerClientConf,
+                             @Parameter(SerializedEMServerClientConfiguration.class)
+                                 final String serializedEMServerClientConf,
                              @Parameter(NumServers.class) final int numServers,
                              final ConfigurationSerializer configurationSerializer,
                              @Parameter(NumWorkerThreads.class) final int numWorkerThreads,
@@ -215,6 +229,9 @@ final class AsyncDolphinDriver {
     this.workerContextsToClose = new ConcurrentLinkedQueue<>();
     this.workerConf = configurationSerializer.fromString(serializedWorkerConf);
     this.paramConf = configurationSerializer.fromString(serializedParamConf);
+    this.emWorkerClientConf = configurationSerializer.fromString(serializedEMWorkerClientConf);
+    this.emServerClientConf = configurationSerializer.fromString(serializedEMServerClientConf);
+
     this.numWorkerThreads = numWorkerThreads;
     this.traceParameters = traceParameters;
 
@@ -327,7 +344,7 @@ final class AsyncDolphinDriver {
           final Configuration traceConf = traceParameters.getConfiguration();
 
           activeContext.submitContextAndService(contextConf,
-              Configurations.merge(serviceConf, traceConf, paramConf));
+              Configurations.merge(serviceConf, traceConf, paramConf, emServerClientConf));
         }
       };
     }
@@ -376,7 +393,7 @@ final class AsyncDolphinDriver {
               .build();
 
           activeContext.submitContextAndService(contextConf,
-              Configurations.merge(serviceConf, traceConf, paramConf, otherParamConf));
+              Configurations.merge(serviceConf, traceConf, paramConf, otherParamConf, emWorkerClientConf));
         }
       };
     }

--- a/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinLauncher.java
+++ b/dolphin-async/src/main/java/edu/snu/cay/async/AsyncDolphinLauncher.java
@@ -26,6 +26,7 @@ import edu.snu.cay.services.em.optimizer.api.Optimizer;
 import edu.snu.cay.services.em.optimizer.conf.OptimizerClass;
 import edu.snu.cay.services.em.plan.api.PlanExecutor;
 import edu.snu.cay.services.em.plan.conf.PlanExecutorClass;
+import edu.snu.cay.services.em.serialize.Serializer;
 import edu.snu.cay.services.ps.ParameterServerConfigurationBuilder;
 import edu.snu.cay.services.ps.common.partitioned.parameters.Dynamic;
 import edu.snu.cay.services.ps.common.partitioned.parameters.NumPartitions;
@@ -90,6 +91,14 @@ public final class AsyncDolphinLauncher {
   final class SerializedWorkerConfiguration implements Name<String> {
   }
 
+  @NamedParameter(doc = "configuration for the EM worker-side client, specifically the Serializer class")
+  final class SerializedEMWorkerClientConfiguration implements Name<String> {
+  }
+
+  @NamedParameter(doc = "configuration for the EM server-side client, specifically the Serializer class")
+  final class SerializedEMServerClientConfiguration implements Name<String> {
+  }
+
   /**
    * Should not be instantiated.
    */
@@ -150,13 +159,26 @@ public final class AsyncDolphinLauncher {
           .bindNamedParameter(SerializedParameterConfiguration.class, confSerializer.toString(userParameterConf))
           .build();
 
+      final Configuration emWorkerClientConf = Tang.Factory.getTang().newConfigurationBuilder()
+          .bindImplementation(Serializer.class, asyncDolphinConfiguration.getWorkerSerializerClass())
+          .build();
+      final Configuration emServerClientConf = Tang.Factory.getTang().newConfigurationBuilder()
+          .bindImplementation(Serializer.class, asyncDolphinConfiguration.getServerSerializerClass())
+          .build();
+
+      final Configuration serializedEMClientConf = Tang.Factory.getTang().newConfigurationBuilder()
+          .bindNamedParameter(SerializedEMWorkerClientConfiguration.class, confSerializer.toString(emWorkerClientConf))
+          .bindNamedParameter(SerializedEMServerClientConfiguration.class, confSerializer.toString(emServerClientConf))
+          .build();
+
+
       // driver-side configurations
       final Configuration driverConf = getDriverConfiguration(jobName, basicParameterInjector);
       final int timeout = basicParameterInjector.getNamedInstance(Timeout.class);
 
       final LauncherStatus status = DriverLauncher.getLauncher(runTimeConf).run(
           Configurations.merge(basicParameterConf, parameterServerConf,
-              serializedWorkerConf, driverConf, customDriverConfiguration),
+              serializedWorkerConf, driverConf, customDriverConfiguration, serializedEMClientConf),
           timeout);
       LOG.log(Level.INFO, "REEF job completed: {0}", status);
       return status;


### PR DESCRIPTION
This PR adds a few functions in `AsyncDolphinLauncher` to set EM `Serializer` classes, which are required during EM.move(). The default `Serializer` to be bound is `JavaSerializer`, which won't work if the data types stored in EM are not `Serializable`s. Apps should implement their own `Serializer`s and bind them using this new interface.

Closes #507.
