### PR TITLE
[Minor] Refine implmentation of Move handlers and fix bugs in them

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/range/MemoryStoreImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/range/MemoryStoreImpl.java
@@ -147,8 +147,7 @@ public final class MemoryStoreImpl implements RemoteAccessibleMemoryStore<Long> 
 
     final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
     if (blocks.containsKey(blockId)) {
-      LOG.log(Level.SEVERE, "Block with id {0} already exists.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + " already exists.");
     }
 
     final Block block = new Block();
@@ -160,14 +159,13 @@ public final class MemoryStoreImpl implements RemoteAccessibleMemoryStore<Long> 
   public Map<Long, Object> getBlock(final String dataType, final int blockId) {
     final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
     if (null == blocks) {
-      LOG.log(Level.FINE, "Data in type {0} has never been stored. The result is empty", dataType);
+      LOG.log(Level.FINE, "Blocks are not initialized for type {0}", dataType);
       return Collections.emptyMap();
     }
 
     final Block block = blocks.get(blockId);
     if (null == block) {
-      LOG.log(Level.SEVERE, "Block with id {0} does not exist.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + "does not exist.");
     }
 
     return block.getAll();
@@ -183,8 +181,7 @@ public final class MemoryStoreImpl implements RemoteAccessibleMemoryStore<Long> 
 
     final Block block = blocks.remove(blockId);
     if (null == block) {
-      LOG.log(Level.SEVERE, "Block with id {0} does not exist.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + "does not exist.");
     }
   }
 

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/singlekey/MemoryStoreImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/singlekey/MemoryStoreImpl.java
@@ -127,8 +127,7 @@ public final class MemoryStoreImpl<K> implements RemoteAccessibleMemoryStore<K> 
 
     final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
     if (blocks.containsKey(blockId)) {
-      LOG.log(Level.SEVERE, "Block with id {0} already exists.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + " already exists.");
     }
 
     final Block block = new Block();
@@ -140,14 +139,13 @@ public final class MemoryStoreImpl<K> implements RemoteAccessibleMemoryStore<K> 
   public Map<K, Object> getBlock(final String dataType, final int blockId) {
     final Map<Integer, Block> blocks = typeToBlocks.get(dataType);
     if (null == blocks) {
-      LOG.log(Level.WARNING, "Data in type {0} has never been stored. The result is empty", dataType);
+      LOG.log(Level.FINE, "Blocks are not initialized for type {0}", dataType);
       return Collections.emptyMap();
     }
 
     final Block block = blocks.get(blockId);
     if (null == block) {
-      LOG.log(Level.SEVERE, "Block with id {0} does not exist.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + "does not exist.");
     }
 
     return block.getAll();
@@ -163,8 +161,7 @@ public final class MemoryStoreImpl<K> implements RemoteAccessibleMemoryStore<K> 
 
     final Block block = blocks.remove(blockId);
     if (null == block) {
-      LOG.log(Level.SEVERE, "Block with id {0} does not exist.", blockId);
-      throw new RuntimeException();
+      throw new RuntimeException("Block with id " + blockId + "does not exist.");
     }
   }
 


### PR DESCRIPTION
Current implementations of Move handler in both `MemoryStore`s do not correctly work, when the blocks for a specific data type are not initialized yet (In other words, the data of a specific type never have been stored).

This PR fixed them to work in these cases and additionally makes some changes for consistency between methods and between `MemoryStore`s.
