### PR TITLE
[MINOR] Add or replace an eval id of a store in Resolver

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/api/EMRoutingTableUpdate.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/api/EMRoutingTableUpdate.java
@@ -35,6 +35,12 @@ public interface EMRoutingTableUpdate {
   int getNewOwnerId();
 
   /**
+   * Returns the eval id where the new store is placed in.
+   * @return an eval id of new store
+   */
+  String getNewEvalId();
+
+  /**
    * Returns the ids of blocks that their locations are updated.
    * @return a list of block id
    */

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/EMRoutingTableUpdateImpl.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/EMRoutingTableUpdateImpl.java
@@ -27,11 +27,14 @@ import java.util.List;
 final class EMRoutingTableUpdateImpl implements EMRoutingTableUpdate {
   private final int oldOwnerId;
   private final int newOwnerId;
+  private final String newEvalId;
   private final List<Integer> blockIds;
 
-  EMRoutingTableUpdateImpl(final int oldOwnerId, final int newOwnerId, final List<Integer> blockIds) {
+  EMRoutingTableUpdateImpl(final int oldOwnerId, final int newOwnerId, final String newEvalId,
+                           final List<Integer> blockIds) {
     this.oldOwnerId = oldOwnerId;
     this.newOwnerId = newOwnerId;
+    this.newEvalId = newEvalId;
     this.blockIds = blockIds;
   }
 
@@ -43,6 +46,11 @@ final class EMRoutingTableUpdateImpl implements EMRoutingTableUpdate {
   @Override
   public int getNewOwnerId() {
     return newOwnerId;
+  }
+
+  @Override
+  public String getNewEvalId() {
+    return newEvalId;
   }
 
   @Override

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/MigrationManager.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/MigrationManager.java
@@ -419,9 +419,10 @@ final class MigrationManager {
   private void notifyUpdate(final Migration migration) {
     final int oldOwnerId = partitionManager.getMemoryStoreId(migration.getSenderId());
     final int newOwnerId = partitionManager.getMemoryStoreId(migration.getReceiverId());
+    final String newEvalId = migration.getReceiverId();
     final List<Integer> blockIds = migration.getBlockIds();
 
-    final EMRoutingTableUpdate update = new EMRoutingTableUpdateImpl(oldOwnerId, newOwnerId, blockIds);
+    final EMRoutingTableUpdate update = new EMRoutingTableUpdateImpl(oldOwnerId, newOwnerId, newEvalId, blockIds);
 
     for (final EventHandler<EMRoutingTableUpdate> callBack : updateCallbacks.values()) {
       callBack.onNext(update);

--- a/services/ps/src/main/avro/parameterserver.avsc
+++ b/services/ps/src/main/avro/parameterserver.avsc
@@ -100,6 +100,7 @@
   [
     {"name": "oldOwnerId", "type": "int"},
     {"name": "newOwnerId", "type": "int"},
+    {"name": "newEvalId", "type": "string"},
     {"name": "blockIds", "type": {"type": "array", "items": "int"}}
   ]
 },

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/common/partitioned/resolver/DynamicServerResolver.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/common/partitioned/resolver/DynamicServerResolver.java
@@ -108,6 +108,11 @@ public final class DynamicServerResolver implements ServerResolver {
   public void updateRoutingTable(final EMRoutingTableUpdate routingTableUpdate) {
     final int oldOwnerId = routingTableUpdate.getOldOwnerId();
     final int newOwnerId = routingTableUpdate.getNewOwnerId();
+    final String newEvalId = routingTableUpdate.getNewEvalId();
+
+    // add or replace an eval id of a store
+    storeIdToEndpointId.put(newOwnerId, newEvalId);
+
     for (final int blockId : routingTableUpdate.getBlockIds()) {
       final int actualOldOwnerId = blockIdToStoreId.put(blockId, newOwnerId);
       if (oldOwnerId != actualOldOwnerId) {

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
@@ -85,11 +85,13 @@ public final class EMRoutingTableManager {
     public void onNext(final EMRoutingTableUpdate emRoutingTableUpdate) {
       final int oldOwnerId = emRoutingTableUpdate.getOldOwnerId();
       final int newOwnerId = emRoutingTableUpdate.getNewOwnerId();
+      final String newEvalID = emRoutingTableUpdate.getNewEvalId();
       final List<Integer> blockIds = emRoutingTableUpdate.getBlockIds();
 
       final RoutingTableUpdateMsg routingTableUpdateMsg = RoutingTableUpdateMsg.newBuilder()
           .setOldOwnerId(oldOwnerId)
           .setNewOwnerId(newOwnerId)
+          .setNewEvalId(newEvalID)
           .setBlockIds(blockIds)
           .build();
 

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/EMRoutingTableUpdateImpl.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/EMRoutingTableUpdateImpl.java
@@ -26,11 +26,14 @@ final class EMRoutingTableUpdateImpl implements EMRoutingTableUpdate {
 
   private final int oldOwnerId;
   private final int newOwnerId;
+  private final String newEvalId;
   private final List<Integer> blockIds;
 
-  EMRoutingTableUpdateImpl(final int oldOwnerId, final int newOwnerId, final List<Integer> blockIds) {
+  EMRoutingTableUpdateImpl(final int oldOwnerId, final int newOwnerId, final String newEvalId,
+                           final List<Integer> blockIds) {
     this.oldOwnerId = oldOwnerId;
     this.newOwnerId = newOwnerId;
+    this.newEvalId = newEvalId;
     this.blockIds = blockIds;
   }
 
@@ -42,6 +45,11 @@ final class EMRoutingTableUpdateImpl implements EMRoutingTableUpdate {
   @Override
   public int getNewOwnerId() {
     return newOwnerId;
+  }
+
+  @Override
+  public String getNewEvalId() {
+    return newEvalId;
   }
 
   @Override

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/WorkerSideMsgHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/WorkerSideMsgHandler.java
@@ -116,9 +116,10 @@ public final class WorkerSideMsgHandler<K, P, V> implements EventHandler<Message
   private void onRoutingTableUpdateMsg(final RoutingTableUpdateMsg routingTableUpdateMsg) {
     final int oldOwnerId = routingTableUpdateMsg.getOldOwnerId();
     final int newOwnerId = routingTableUpdateMsg.getNewOwnerId();
+    final String newEvalId = routingTableUpdateMsg.getNewEvalId().toString();
     final List<Integer> blockIds = routingTableUpdateMsg.getBlockIds();
 
-    serverResolver.updateRoutingTable(new EMRoutingTableUpdateImpl(oldOwnerId, newOwnerId, blockIds));
+    serverResolver.updateRoutingTable(new EMRoutingTableUpdateImpl(oldOwnerId, newOwnerId, newEvalId, blockIds));
   }
 
   private void onReplyMsg(final ReplyMsg replyMsg) {


### PR DESCRIPTION
Since #499, `blockIdToStoreId` mapping in `DynamicServerResolver` can adopt the updates by _Move_.

But it does not consider the case of Move to new evaluators added by _Add_, which requires additional updates in `storeIdToEndPointId` mapping.

This PR fixes this problem.
