### PR TITLE
[CAY-407] Update REEF version to 0.15.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.14.0-SNAPSHOT</reef.version>
+    <reef.version>0.15.0-SNAPSHOT</reef.version>
     <hadoop.version>2.6.0</hadoop.version>
     <htrace.version>3.0.4</htrace.version>
     <mahout.version>0.9</mahout.version>


### PR DESCRIPTION
Closes #407.

I've checked that all major examples (namely dolphin-async, ps, elastic-memory, and aggregation) complete without any errors. Obviously, you need to have a successful build of REEF 0.15.0-SNAPSHOT in your local machine before you can test this.
