### PR TITLE
[CAY-537] Upgrade Cay to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <showDeprecation>true</showDeprecation>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>


### PR DESCRIPTION
Closes #537 
Java 8 on Cay has been tested with JUnit in maven build.
The below tests have been run and verified as well.
1. dolphin-bsp: run.sh, run_kmeans.sh, run_logistic.sh, run_regression.sh
2. dolphin-async: run_addinteger.sh, run_mlr.sh, run_nmf.sh
3. EM: run_simple.sh
4. PS: run.sh
