### PR TITLE
[MINOR] Upgrade REEF dependency to 0.16.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.15.0-SNAPSHOT</reef.version>
+    <reef.version>0.16.0-SNAPSHOT</reef.version>
     <hadoop.version>2.6.0</hadoop.version>
     <htrace.version>3.0.4</htrace.version>
     <mahout.version>0.9</mahout.version>


### PR DESCRIPTION
As REEF 15.0 was released, the latest snapshot is updated to 0.16.0-SNAPSHOT. Cay currently depends on 0.15.0-SNAPSHOT, which does not allow to build on the REEF's master branch (we need to checkout to the previous commit before the version was changed).
This PR upgrade REEF dependency to remove the subtlety in the build process.
