### PR TITLE
[MINOR] Fix namespace in script to run LDA

### DIFF
--- a/dolphin/async/bin/run_lda.sh
+++ b/dolphin/async/bin/run_lda.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_lda.sh -input sample_lda -local true -split 4 -numServers 2 -numTopics 10 -numVocabs 102656 -maxIter 3 -maxNumEvalLocal 6 -numWorkerThreads 1 -timeout 180000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.async.optimizer.AsyncDolphinPlanExecutor -optimizationIntervalMs 3000 -memoryStoreInitDelayMs 1000 -delayAfterOptimizationMs 10000
+# ./run_lda.sh -input sample_lda -local true -split 4 -numServers 2 -numTopics 10 -numVocabs 102656 -maxIter 3 -maxNumEvalLocal 6 -numWorkerThreads 1 -timeout 180000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimizationIntervalMs 3000 -memoryStoreInitDelayMs 1000 -delayAfterOptimizationMs 10000
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 
@@ -24,7 +24,7 @@ CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:
 
 YARN_CONF_DIR=$YARN_HOME/etc/hadoop
 
-ALG=edu.snu.cay.async.examples.lda.LdaREEF
+ALG=edu.snu.cay.dolphin.async.mlapps.lda.LdaREEF
 
 CMD="java -cp $YARN_CONF_DIR:$SELF_JAR:$CLASSPATH $LOGGING_CONFIG $ALG $*"
 echo $CMD


### PR DESCRIPTION
In the script to run LDA (dolphin/async/bin/run_lda.sh), the namespace is obsolete, where the changes in dolphin reorg (#542) were not included.

This PR updates the namespaces in the script, for example, `e.s.c.async.example.lda` to `e.s.c.dolphin.async.mlapps.lda`.
