### PR TITLE
[MINOR] Remove init check from OperationRouter.getInitialLocalBlocksIds()

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/OperationRouter.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/evaluator/impl/OperationRouter.java
@@ -103,12 +103,14 @@ public final class OperationRouter<K> {
     this.numTotalBlocks = numTotalBlocks;
     this.numInitialEvals = numInitialEvals;
     this.addedEval = addedEval;
-
-    final int numInitialLocalBlocks = addedEval ? 0 : (numTotalBlocks / numInitialEvals + 1); // +1 for remainders
-    this.initialLocalBlocks = new ArrayList<>(numInitialLocalBlocks);
     this.blockLocations = new AtomicIntegerArray(numTotalBlocks);
+
     if (!addedEval) {
+      final int numInitialLocalBlocks = numTotalBlocks / numInitialEvals + 1; // +1 for remainders
+      this.initialLocalBlocks = new ArrayList<>(numInitialLocalBlocks);
       initRoutingTable();
+    } else {
+      this.initialLocalBlocks = Collections.emptyList();
     }
   }
 
@@ -291,8 +293,6 @@ public final class OperationRouter<K> {
    * @return a list of block ids which are initially assigned to the local MemoryStore.
    */
   public List<Integer> getInitialLocalBlockIds() {
-    checkInitialization();
-
     return Collections.unmodifiableList(initialLocalBlocks);
   }
 


### PR DESCRIPTION
To obtain the block information, MemoryStore invokes OperationRouter's `getInitialLocalBlockIds()` when initializing itself.

The current implementation of `getInitialLocalBlockIds()` method checks the initialization (whether the router of added evals are initialized with up-to-date routing table).
But we do not require the init of router for this method, because the initial blocks for evaluators are statically fixed for all evaluators; evenly distributed (round-robin) blocks for initial evaluators, empty for added evaluators.

This PR removes the init check in `getInitialLocalBlockIds()`, since it is unnecessary and also contains an infeasible injection plan, which only happens with added evaluators.
`MemoryStore's constructor -> getInitialLocalBlockIds() -> checkInitialization() -> InjectionFuture<ElasticMemoryMsgSender>.get()`
