### PR TITLE
[MINOR] Fix and clean up sample optimizers

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/optimizer/impl/AddOneOptimizer.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/optimizer/impl/AddOneOptimizer.java
@@ -63,11 +63,14 @@ public final class AddOneOptimizer implements Optimizer {
 
     final PlanImpl.Builder planBuilder = PlanImpl.newBuilder();
 
-    for (final String namespace : evalParamsMap.keySet()) {
+    for (final Map.Entry<String, List<EvaluatorParameters>> entry : evalParamsMap.entrySet()) {
+      final String namespace = entry.getKey();
+      final List<EvaluatorParameters> evalParams = entry.getValue();
+
       planBuilder.addEvaluatorToAdd(namespace, evaluatorToAdd);
 
       EvaluatorParameters srcEvaluator = null;
-      for (final EvaluatorParameters evaluator : evalParamsMap.get(namespace)) {
+      for (final EvaluatorParameters evaluator : evalParams) {
         if (evaluator.getDataInfo().getNumBlocks() > 0) {
           srcEvaluator = evaluator;
           break;

--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/optimizer/impl/RandomOptimizer.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/optimizer/impl/RandomOptimizer.java
@@ -108,11 +108,13 @@ public final class RandomOptimizer implements Optimizer {
 
     final PlanImpl.Builder planBuilder = PlanImpl.newBuilder();
 
-    for (final String namespace : evalParamsMap.keySet()) {
+    for (final Map.Entry<String, List<EvaluatorParameters>> entry : evalParamsMap.entrySet()) {
+      final String namespace = entry.getKey();
+      final List<EvaluatorParameters> evalParams = entry.getValue();
 
       final List<EvaluatorParameters> evaluatorsToAdd;
       final List<EvaluatorParameters> evaluatorsToDelete;
-      final List<EvaluatorParameters> activeEvaluators = new ArrayList<>(evalParamsMap.get(namespace));
+      final List<EvaluatorParameters> activeEvaluators = new ArrayList<>(evalParams);
       if (numEvaluators > activeEvaluators.size()) {
         evaluatorsToDelete = new ArrayList<>(0);
         evaluatorsToAdd = getNewEvaluators(numEvaluators - activeEvaluators.size()); // Add to the tail


### PR DESCRIPTION
This PR fixes and cleans up the sample optimizers (`AddOneOptimizer`, `DeleteOneOptimizer`, and `RandomOptimizer`).

Modifications to DeleteOneOptimizer:
1. Check the number of evaluators before deletion regardless of the number of blocks assigned.
2. Explicitly add deletion operations to the plan instead of including the deletion as a part of move (TransferStep)

Change to all the sample optimizers:
Use Map.entrySet for iterating over the evaluator parameters instead of calling Map.keySet() and iterating over the values from Map.get() on each of the key values.
