### PR TITLE
[MINOR] Use a bookkeeping of RunningTasks when deleting workers

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
@@ -937,7 +937,7 @@ public final class AsyncDolphinDriver {
         runningTask.close();
         deletedWorkerContextIds.add(activeContextId);
 
-        // context will be closed in ClosedTaskHandler or unintentionally by FailedTaskHandler
+        // context will be closed in ClosedTaskHandler, or in FailedTaskHandler when Task accidentally fails
         LOG.log(Level.FINE, "Worker has been deleted successfully. Remaining workers: {0}",
             contextIdToWorkerTasks.size());
         isSuccess = true;


### PR DESCRIPTION
The current implementation of `AsyncDolphinDriver` fails when _deleting_ workers.

It is because `WorkerRemover` uses a bookkeeping of worker contexts, when checking whether the task is alive. `WorkerRemover` should use a bookkeeping of worker tasks, because worker contexts are not closed together with the tasks.

For this reason, [L936](https://github.com/cmssnu/cay/pull/581/files#diff-9e55f6423bcbc951abeed2588b71d120L936) in original code throws NullPointerException, when EM tries to _delete_ the evaluator of finished workers.
