### PR TITLE
[CAY-450] Enabled Final Class Checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -169,7 +169,10 @@
 
     <!-- Checks for class design                         -->
     <!-- See http://checkstyle.sf.net/config_design.html -->
-    <module name="FinalClass"/>
+    <module name="FinalClass">
+      <property name="severity" value="error"/>
+		</module>
+
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
     <module name="VisibilityModifier">


### PR DESCRIPTION
the 'FinalClass' module in the 'checkstyle.xml' has been enabled now. 

If you want to check if it works properly by yourself, you may want to remove 'final' keyword from a class definition whose constructors are defined as private. As an example, you can check it by removing 'final' keyword from 'AsyncDolphinConfiguration' class definition in the 'AsyncDolphinConfiguration.java' file. 

Thank you for your review!
