### PR TITLE
[CAY-595] Add a unit test for OperationRouter

### DIFF
--- a/services/elastic-memory/src/test/java/edu/snu/cay/services/em/evaluator/impl/OperationRouterTest.java
+++ b/services/elastic-memory/src/test/java/edu/snu/cay/services/em/evaluator/impl/OperationRouterTest.java
@@ -121,6 +121,7 @@ public class OperationRouterTest {
 
           targetStoreId = storeId;
         } else {
+          // TODO #509: remove the assumption on the format of context id
           targetStoreId = Integer.valueOf(evalId.get().split("-")[1]);
         }
 


### PR DESCRIPTION
Resolves #595.

This PR implements a unit test for `OperationRouter`.

Note that this test does not cover the initialization of routers for stores dynamically added by EM.add().
I'm gonna add that part in #594.
