### PR TITLE
[MINOR] Fix a bug in Tracer where data has not arrived to newly added MemoryStore

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/Tracer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/Tracer.java
@@ -47,15 +47,17 @@ public class Tracer {
 
   public double avg() {
     if (count == 0) {
-      return 0;
+      return Double.POSITIVE_INFINITY;
     }
+
     return sum / count / 1000.0D;
   }
 
   public double avgElement() {
-    if (count == 0) {
-      return 0;
+    if (elemCount == 0) {
+      return Double.POSITIVE_INFINITY;
     }
+
     return sum / elemCount / 1000.0D;
   }
 }


### PR DESCRIPTION
Current `Tracer` implementation does not care the cases that may throw `ArithmeticException` (divide by zero).
And it definitely happens when workers are newly added by EM.

This PR resolve this problem by simply checking whether the denominator is zero.
