### PR TITLE
[MINOR] Fix checkstyle violation in OperationRouterTest

### DIFF
--- a/services/elastic-memory/src/test/java/edu/snu/cay/services/em/evaluator/impl/OperationRouterTest.java
+++ b/services/elastic-memory/src/test/java/edu/snu/cay/services/em/evaluator/impl/OperationRouterTest.java
@@ -73,7 +73,8 @@ public class OperationRouterTest {
     final Set<Integer> totalBlocks = new HashSet<>(numTotalBlocks);
 
     for (int localStoreId = 0; localStoreId < numMemoryStores; localStoreId++) {
-      final OperationRouter<?> operationRouter = newOperationRouter(numMemoryStores, numTotalBlocks, localStoreId, false);
+      final OperationRouter<?> operationRouter =
+          newOperationRouter(numMemoryStores, numTotalBlocks, localStoreId, false);
 
       final List<Integer> localBlockIds = operationRouter.getInitialLocalBlockIds();
 
@@ -152,7 +153,8 @@ public class OperationRouterTest {
     assertTrue("Router is initialized incorrectly", srcInitialBlocks.containsAll(srcCurrentBlocks));
 
     final int destStoreId = 1;
-    final OperationRouter<?> destRouter = newOperationRouter(numInitialMemoryStores, numTotalBlocks, destStoreId, false);
+    final OperationRouter<?> destRouter =
+        newOperationRouter(numInitialMemoryStores, numTotalBlocks, destStoreId, false);
 
     // move the half of blocks between two evaluators by updating routers
     final int numBlocksToMove = srcInitialBlocks.size() / 2;


### PR DESCRIPTION
@wynot12 reported that merging #610 has caused a checkstyle violation. In `OperationRouterTest`, there are two lines that exceed 120 characters, which I failed to find while reviewing the PR. Sorry for inconvenience.

**NOTICE**: CI is down due to the cluster maintenance issue. Reviewers must run the test manually, and must include testing on at least one linux environment where our CI was running.
