### PR TITLE
[MINOR] Add comment about logging for exception in AsyncDolphinLauncher

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
@@ -200,8 +200,11 @@ public final class AsyncDolphinLauncher {
 
     } catch (final Exception e) {
       final LauncherStatus status = LauncherStatus.failed(e);
-      LOG.log(Level.WARNING, "Exception occurred", e);
       LOG.log(Level.INFO, "REEF job completed: {0}", status);
+
+      // This log is for giving more detailed info about failure, which status object does not show
+      LOG.log(Level.WARNING, "Exception occurred", e);
+
       return status;
     }
   }


### PR DESCRIPTION
#624 recently introduced a line for logging exceptions, but comment is missing. While reviewing the PR, @wynot12 raised a question about this change. This PR is adding a comment about why we'd like to add it; this logging is exclusively helpful when the command line parameters are invalid, as Tang does not give sufficient information to reason about.

Another motivation to send this PR is to test CI, which seems back now. 
