### PR TITLE
[MINOR] Fix BlockManager to reject moving blocks for non-positive numbers

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/BlockManager.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/BlockManager.java
@@ -251,6 +251,10 @@ public final class BlockManager {
    * @return list of block ids that have been chosen.
    */
   synchronized List<Integer> chooseBlocksToMove(final String evalId, final int numBlocks) {
+    if (numBlocks <= 0) {
+      Collections.emptyList();
+    }
+
     final int storeId = getMemoryStoreId(evalId);
     final Set<Integer> blockIds = storeIdToBlockIds.get(storeId);
 


### PR DESCRIPTION
The current implementation of `BlockManager` assumes that _numblocks_ input parameter for `List<Integer> chooseBlocksToMove(final String evalId, final int numBlocks)` is always positive integer.

Unfortunately, calling this method with 0 or negative number of blocks makes it return whole blocks in the store. It may bring an unintended huge migration.

This PR fixes the problem.
