### PR TITLE
[CAY-632] Make NMFWorker update its keys when sending push/pull requests

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFWorker.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFWorker.java
@@ -195,13 +195,13 @@ final class NMFWorker implements Worker {
     gradients.clear();
   }
 
-  private void pullRMatrix(final List<Integer> pKeys) {
+  private void pullRMatrix(final List<Integer> keys) {
     pullTracer.startTimer();
-    final List<Vector> vectors = parameterWorker.pull(pKeys);
-    for (int i = 0; i < pKeys.size(); ++i) {
-      rMatrix.put(pKeys.get(i), vectors.get(i));
+    final List<Vector> vectors = parameterWorker.pull(keys);
+    for (int i = 0; i < keys.size(); ++i) {
+      rMatrix.put(keys.get(i), vectors.get(i));
     }
-    pullTracer.recordTime(pKeys.size());
+    pullTracer.recordTime(keys.size());
   }
 
   private void resetTracers() {


### PR DESCRIPTION
Closes #632.

Due to elasticity, the keys to send push/pull request in NMFWorker may change over time, but the current code does not consider this aspect. This PR addresses the issue by updating NMFWorker's keys in each iteration.

You can reproduce the failure by launching NMF on the master branch with `AddOneOptimizer`. If you run the job with the same configuration on this branch, it'll finish with no problem.
