### PR TITLE
[MINOR] Make OptimizationOrchestrator.run() as a synchronized, blocking call

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/OptimizationOrchestrator.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/OptimizationOrchestrator.java
@@ -167,7 +167,7 @@ public final class OptimizationOrchestrator {
     try {
       future.get();
     } catch (final InterruptedException | ExecutionException e) {
-      LOG.log(Level.SEVERE, "Exception while executing optimization");
+      LOG.log(Level.SEVERE, "Exception while executing optimization", e);
     }
   }
 


### PR DESCRIPTION
In the current implementation of `OptimizationOrchestrator`, its `run()` method is a non-blocking call, which can be called at anytime by multiple threads. But it's obvious that we should not allow multiple optimizations simultaneously.
In addition, non-blocking execution swallows the exceptions during the optimization, which makes debugging hard.

To resolve this issues, this PR makes `OptimizationOrchestrator.run()` a synchronized blocking call that waits until the optimization is finished.
