### PR TITLE
[MINOR] Remove counting NamedParamters from AsyncDolphinLauncher

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
@@ -70,7 +70,7 @@ import org.apache.reef.wake.remote.impl.Tuple2;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -225,7 +225,7 @@ public final class AsyncDolphinLauncher {
     final CommandLine cl = new CommandLine(cb);
 
     // add all basic parameters
-    final List<Class<? extends Name<?>>> basicParameterClassList = new ArrayList<>(28);
+    final List<Class<? extends Name<?>>> basicParameterClassList = new LinkedList<>();
     basicParameterClassList.add(EvaluatorSize.class);
     basicParameterClassList.add(InputDir.class);
     basicParameterClassList.add(OnLocal.class);


### PR DESCRIPTION
We have specified the number of parameters in AsyncDolphinLauncher as follows:

```
// add all basic parameters
final List<Class<? extends Name<?>>> basicParameterClassList = new ArrayList<>(28);
```

This worked well at the first time, but it's been difficult to track the exact number of parameters as many parameters have been added. Moreover, specifying wrong number of parameters does not affect since the number is just the initial capacity of the list.

Hence, we've concluded to remove it by changing the list to `LinkedList`.
