### PR TITLE
[MINOR] Handle when a given dataSet size is smaller than TrainErrorDatasetSize

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRWorker.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRWorker.java
@@ -425,7 +425,9 @@ final class MLRWorker implements Worker {
     double loss = 0;
     int numInstances = 0;
     int correctPredictions = 0;
-    for (final Pair<Vector, Integer> entry : data.subList(0, datasetSize)) {
+
+    final int numDataToCompute = Math.min(datasetSize, data.size());
+    for (final Pair<Vector, Integer> entry : data.subList(0, numDataToCompute)) {
       final Vector features = entry.getFirst();
       final int label = entry.getSecond();
       final Vector predictions = predict(features);


### PR DESCRIPTION
The current `MLRWorker` implementation may throw `IndexOutOfBoundException` when computing loss.

It is because it does not care the case that a sample data size for computing loss is smaller than the size of entire data. This problem commonly happens when the entire data are migrated to other evaluators for Delete.

As a hotfix, this PR choose the minimum between the number of data size to compute loss and actual data set size.
