### PR TITLE
[MINOR] Remove numWorkerThreads from dolphin-async

### DIFF
--- a/common/src/main/java/edu/snu/cay/common/param/Parameters.java
+++ b/common/src/main/java/edu/snu/cay/common/param/Parameters.java
@@ -63,12 +63,6 @@ public final class Parameters {
   public final class Iterations implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Number of computation threads for each worker",
-                  short_name = "num_worker_threads",
-                  default_value = "2")
-  public final class NumWorkerThreads implements Name<Integer> {
-  }
-
   @NamedParameter(doc = "The fraction of the container memory NOT to use for the Java Heap",
                   short_name = "heap_slack",
                   default_value = "0.0")

--- a/dolphin/async/bin/run_dnn.sh
+++ b/dolphin/async/bin/run_dnn.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_dnn.sh -local true -max_iter 100 -conf sample_dnn_conf -input sample_dnn_data -split 2 -max_num_eval_local 3 -num_worker_threads 1 -timeout 800000 -dynamic false -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_dnn.sh -local true -max_iter 100 -conf sample_dnn_conf -input sample_dnn_data -split 2 -max_num_eval_local 3 -timeout 800000 -dynamic false -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_lda.sh
+++ b/dolphin/async/bin/run_lda.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_lda.sh -input sample_lda -local true -split 4 -num_servers 2 -num_topics 10 -num_vocabs 102656 -max_iter 3 -max_num_eval_local 6 -num_worker_threads 1 -timeout 180000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_lda.sh -input sample_lda -local true -split 4 -num_servers 2 -num_topics 10 -num_vocabs 102656 -max_iter 3 -max_num_eval_local 6 -timeout 180000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_mlr.sh
+++ b/dolphin/async/bin/run_mlr.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_mlr.sh -split 4 -num_servers 2 -num_partitions 4 -num_worker_threads 1 -local true -input sample_mlr -max_num_eval_local 7 -max_iter 20 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -num_mini_batch 3 -lambda 0.005 -timeout 200000 -status_log_period 5 -decay_period 5 -decay_rate 0.9 -num_batch_per_loss_log 1 -train_error_dataset_size 30 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_mlr.sh -split 4 -num_servers 2 -num_partitions 4 -local true -input sample_mlr -max_num_eval_local 7 -max_iter 20 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -num_mini_batch 3 -lambda 0.005 -timeout 200000 -status_log_period 5 -decay_period 5 -decay_rate 0.9 -num_batch_per_loss_log 1 -train_error_dataset_size 30 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_nmf.sh
+++ b/dolphin/async/bin/run_nmf.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_nmf.sh -max_iter 500 -local true -split 4 -max_num_eval_local 5 -num_worker_threads 1 -input sample_nmf -num_mini_batch 5 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_nmf.sh -max_iter 500 -local true -split 4 -max_num_eval_local 5 -input sample_nmf -num_mini_batch 5 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -dynamic false -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
@@ -22,7 +22,6 @@ import edu.snu.cay.dolphin.async.metric.WorkerMetricsMsgSender;
 import edu.snu.cay.dolphin.async.optimizer.*;
 import edu.snu.cay.dolphin.async.optimizer.parameters.OptimizationIntervalMs;
 import edu.snu.cay.common.aggregation.driver.AggregationManager;
-import edu.snu.cay.common.param.Parameters.NumWorkerThreads;
 import edu.snu.cay.services.em.avro.AvroElasticMemoryMessage;
 import edu.snu.cay.services.em.avro.Result;
 import edu.snu.cay.services.em.avro.ResultMsg;
@@ -221,11 +220,6 @@ public final class AsyncDolphinDriver {
   private final Configuration emServerClientConf;
 
   /**
-   * Number of computation threads for each evaluator.
-   */
-  private final int numWorkerThreads;
-
-  /**
    * Factory used when establishing network connection.
    */
   private final IdentifierFactory identifierFactory;
@@ -297,7 +291,6 @@ public final class AsyncDolphinDriver {
                                  final String serializedEMServerClientConf,
                              @Parameter(NumServers.class) final int numServers,
                              final ConfigurationSerializer configurationSerializer,
-                             @Parameter(NumWorkerThreads.class) final int numWorkerThreads,
                              @Parameter(OptimizationIntervalMs.class) final long optimizationIntervalMs,
                              final MetricsHub metricsHub,
                              final HTraceParameters traceParameters,
@@ -317,7 +310,6 @@ public final class AsyncDolphinDriver {
     this.emWorkerClientConf = configurationSerializer.fromString(serializedEMWorkerClientConf);
     this.emServerClientConf = configurationSerializer.fromString(serializedEMServerClientConf);
 
-    this.numWorkerThreads = numWorkerThreads;
     this.traceParameters = traceParameters;
     this.optimizationIntervalMs = optimizationIntervalMs;
 
@@ -558,12 +550,9 @@ public final class AsyncDolphinDriver {
             getMetricsCollectionServiceConfForWorker());
         final Configuration traceConf = traceParameters.getConfiguration();
 
-        final Configuration otherParamConf = Tang.Factory.getTang().newConfigurationBuilder()
-            .bindNamedParameter(NumWorkerThreads.class, Integer.toString(numWorkerThreads))
-            .build();
-
+        // TODO #681: Need to add configuration for numWorkerThreads after multi-thread worker is enabled
         activeContext.submitContextAndService(contextConf,
-            Configurations.merge(serviceConf, traceConf, paramConf, otherParamConf, workerConf, emWorkerClientConf));
+            Configurations.merge(serviceConf, traceConf, paramConf, workerConf, emWorkerClientConf));
       }
     };
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
@@ -225,12 +225,12 @@ public final class AsyncDolphinLauncher {
     final CommandLine cl = new CommandLine(cb);
 
     // add all basic parameters
+    // TODO #681: Need to add configuration for numWorkerThreads after multi-thread worker is enabled
     final List<Class<? extends Name<?>>> basicParameterClassList = new LinkedList<>();
     basicParameterClassList.add(EvaluatorSize.class);
     basicParameterClassList.add(InputDir.class);
     basicParameterClassList.add(OnLocal.class);
     basicParameterClassList.add(Splits.class);
-    basicParameterClassList.add(NumWorkerThreads.class);
     basicParameterClassList.add(Timeout.class);
     basicParameterClassList.add(LocalRuntimeMaxNumEvaluators.class);
     basicParameterClassList.add(Iterations.class);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
@@ -16,15 +16,7 @@
 package edu.snu.cay.dolphin.async;
 
 import  edu.snu.cay.common.param.Parameters.Iterations;
-import edu.snu.cay.common.param.Parameters.NumWorkerThreads;
-import edu.snu.cay.services.em.evaluator.api.DataIdFactory;
-import edu.snu.cay.services.em.evaluator.impl.OperationRouter;
-import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.Text;
 import org.apache.reef.driver.task.TaskConfigurationOptions.Identifier;
-import org.apache.reef.io.data.loading.api.DataSet;
-import org.apache.reef.io.network.util.Pair;
-import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.task.Task;
@@ -32,19 +24,11 @@ import org.apache.reef.task.events.CloseEvent;
 import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * REEF Task for worker threads of {@code dolphin-async} applications.
- * Spawns several computation threads and runs them using
- * a fixed thread pool ({@link Executors#newFixedThreadPool(int)}.
+ * REEF Task for a worker thread of {@code dolphin-async} applications.
  */
 @Unit
 final class AsyncWorkerTask implements Task {
@@ -53,10 +37,8 @@ final class AsyncWorkerTask implements Task {
 
   private final String taskId;
   private final int maxIterations;
-  private final int numWorkerThreads;
   private final WorkerSynchronizer synchronizer;
-  private final Injector injector;
-  private final DataSet<LongWritable, Text> dataSet;
+  private final Worker worker;
 
   /**
    * A boolean flag shared among all worker threads.
@@ -67,109 +49,39 @@ final class AsyncWorkerTask implements Task {
   @Inject
   private AsyncWorkerTask(@Parameter(Identifier.class) final String taskId,
                           @Parameter(Iterations.class) final int maxIterations,
-                          @Parameter(NumWorkerThreads.class) final int numWorkerThreads,
                           final WorkerSynchronizer synchronizer,
-                          final Injector injector,
-                          final DataIdFactory<Long> idFactory,
-                          final OperationRouter<Long> router,
-                          final DataSet<LongWritable, Text> dataSet) {
-    // inject DataIdFactory and OperationRouter here to make spawning threads share the same instances
+                          final Worker worker) {
     this.taskId = taskId;
     this.maxIterations = maxIterations;
-    this.numWorkerThreads = numWorkerThreads;
     this.synchronizer = synchronizer;
-    this.injector = injector;
-    this.dataSet = dataSet;
+    this.worker = worker;
   }
 
   @Override
   public byte[] call(final byte[] memento) throws Exception {
     LOG.log(Level.INFO, "{0} starting...", taskId);
 
-    final AsyncWorkerDataSet[] asyncWorkerDataSets = divideDataSets();
-    final ExecutorService executorService = Executors.newFixedThreadPool(numWorkerThreads);
-    final Future[] futures = new Future[numWorkerThreads];
+    // TODO #681: Need to add numWorkerThreads concept after multi-thread worker is enabled
+    worker.initialize();
 
-    LOG.log(Level.INFO, "Initializing {0} worker threads", numWorkerThreads);
-    for (int index = 0; index < numWorkerThreads; index++) {
-      // since a single injector only gives singleton instances,
-      // we need to fork the given injector every time we spawn a new thread
-      final Injector forkedInjector = injector.forkInjector();
-      forkedInjector.bindVolatileInstance(DataSet.class, asyncWorkerDataSets[index]);
+    // synchronize all workers before starting the main iteration
+    // to avoid meaningless iterations by the workers who started earlier
+    synchronizer.globalBarrier();
 
-      final Worker worker = forkedInjector.getInstance(Worker.class);
-      futures[index] = executorService.submit(new Runnable() {
-        @Override
-        public void run() {
-          worker.initialize();
-
-          // synchronize all workers before starting the main iteration
-          // to avoid meaningless iterations by the workers who started earlier
-          synchronizer.globalBarrier();
-
-          for (int iteration = 0; iteration < maxIterations; ++iteration) {
-            if (aborted) {
-              LOG.log(Level.INFO, "Abort a thread to completely close the task");
-              return;
-            }
-            worker.run();
-          }
-
-          // Synchronize all workers before cleanup for workers
-          // to finish with the globally equivalent view of trained model
-          synchronizer.globalBarrier();
-
-          worker.cleanup();
-        }
-      });
+    for (int iteration = 0; iteration < maxIterations; ++iteration) {
+      if (aborted) {
+        LOG.log(Level.INFO, "Abort a thread to completely close the task");
+        return null;
+      }
+      worker.run();
     }
 
-    // wait until all threads terminate
-    for (int index = 0; index < numWorkerThreads; index++) {
-      futures[index].get();
-    }
+    // Synchronize all workers before cleanup for workers
+    // to finish with the globally equivalent view of trained model
+    synchronizer.globalBarrier();
 
+    worker.cleanup();
     return null;
-  }
-
-  /**
-   * Split the given dataset across worker computation threads, round-robin fashion.
-   */
-  private AsyncWorkerDataSet[] divideDataSets() {
-    final AsyncWorkerDataSet[] asyncWorkerDataSets = new AsyncWorkerDataSet[numWorkerThreads];
-    for (int index = 0; index < numWorkerThreads; index++) {
-      asyncWorkerDataSets[index] = new AsyncWorkerDataSet();
-    }
-
-    int dataSetIndex = 0;
-    for (final Pair<LongWritable, Text> pair : dataSet) {
-      asyncWorkerDataSets[dataSetIndex].addPair(pair);
-      dataSetIndex = (dataSetIndex + 1) % numWorkerThreads;
-    }
-
-    return asyncWorkerDataSets;
-  }
-
-  /**
-   * {@link DataSet} implementation for worker computation threads.
-   * Internally stores a list of data pairs that are exposed to threads as an {@link Iterator}.
-   */
-  private final class AsyncWorkerDataSet implements DataSet<LongWritable, Text> {
-
-    private final List<Pair<LongWritable, Text>> dataSet;
-
-    AsyncWorkerDataSet() {
-      dataSet = new LinkedList<>();
-    }
-
-    void addPair(final Pair<LongWritable, Text> pair) {
-      dataSet.add(pair);
-    }
-
-    @Override
-    public Iterator<Pair<LongWritable, Text>> iterator() {
-      return dataSet.iterator();
-    }
   }
 
   final class CloseEventHandler implements EventHandler<CloseEvent> {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerSynchronizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerSynchronizer.java
@@ -17,12 +17,10 @@ package edu.snu.cay.dolphin.async;
 
 import edu.snu.cay.common.aggregation.avro.AggregationMessage;
 import edu.snu.cay.common.aggregation.slave.AggregationSlave;
-import edu.snu.cay.common.param.Parameters.NumWorkerThreads;
 import edu.snu.cay.utils.StateMachine;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.network.group.impl.utils.ResettingCountDownLatch;
 import org.apache.reef.io.serialization.SerializableCodec;
-import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
 
@@ -50,10 +48,10 @@ final class WorkerSynchronizer {
 
   @Inject
   private WorkerSynchronizer(final AggregationSlave aggregationSlave,
-                             final SerializableCodec<String> codec,
-                             @Parameter(NumWorkerThreads.class) final int numWorkerThreads) {
+                             final SerializableCodec<String> codec) {
     this.localStateMachine = SynchronizationManager.initStateMachine();
-    this.cyclicBarrier = new CyclicBarrier(numWorkerThreads, new Runnable() {
+    // TODO #681: Need to add numWorkerThreads concept after multi-thread worker is enabled
+    this.cyclicBarrier = new CyclicBarrier(1, new Runnable() {
       @Override
       public void run() {
         LOG.log(Level.INFO, "Sending a synchronization message to the driver");

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerWorker.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerWorker.java
@@ -81,16 +81,16 @@ final class AddIntegerWorker implements Worker {
                            @Parameter(AddIntegerREEF.NumKeys.class) final int numberOfKeys,
                            @Parameter(AddIntegerREEF.NumUpdates.class) final int numberOfUpdates,
                            @Parameter(AddIntegerREEF.NumWorkers.class) final int numberOfWorkers,
-                           @Parameter(Parameters.NumWorkerThreads.class) final int numWorkerThreads,
                            @Parameter(Parameters.Iterations.class) final int numIterations) {
     this.parameterWorker = parameterWorker;
     this.delta = delta;
     this.startKey = startKey;
     this.numberOfKeys = numberOfKeys;
     this.numberOfUpdates = numberOfUpdates;
-    this.expectedResult = delta * numberOfWorkers * numWorkerThreads * numIterations * numberOfUpdates;
-    LOG.log(Level.INFO, "delta:{0}, numWorkers:{1}, numWorkerThreads:{2}, numIterations:{3}, numberOfUpdates:{4}",
-        new Object[]{delta, numberOfWorkers, numWorkerThreads, numIterations, numberOfUpdates});
+    // TODO #681: Need to consider numWorkerThreads after multi-thread worker is enabled
+    this.expectedResult = delta * numberOfWorkers * numIterations * numberOfUpdates;
+    LOG.log(Level.INFO, "delta:{0}, numWorkers:{1}, numIterations:{2}, numberOfUpdates:{3}",
+        new Object[]{delta, numberOfWorkers, numIterations, numberOfUpdates});
   }
 
   @Override


### PR DESCRIPTION
This pull request removes worker thread concept from dolphin-async framework, since current implementation of multi-thread worker is not correct. We should resolve issue #681 to train with multi-thread worker.
