### PR TITLE
[MINOR] Change logging level of ReconfigurationTest to ALL for debugging

### DIFF
--- a/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/integration/ReconfigurationTest.java
+++ b/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/integration/ReconfigurationTest.java
@@ -18,6 +18,7 @@ package edu.snu.cay.dolphin.async.integration;
 import edu.snu.cay.dolphin.async.examples.addinteger.AddIntegerREEF;
 import edu.snu.cay.dolphin.async.optimizer.AsyncDolphinPlanExecutor;
 import edu.snu.cay.dolphin.async.optimizer.OptimizationOrchestrator;
+import edu.snu.cay.utils.TestLoggingConfig;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
@@ -39,6 +40,8 @@ public class ReconfigurationTest {
     final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindImplementation(OptimizationOrchestrator.class, TestingOrchestrator.class)
         .build();
+
+    System.setProperty("java.util.logging.config.class", TestLoggingConfig.class.getName());
 
     assertEquals("The job has been failed", LauncherStatus.COMPLETED, AddIntegerREEF.runAddInteger(args, conf));
   }

--- a/utils/src/main/java/edu/snu/cay/utils/TestLoggingConfig.java
+++ b/utils/src/main/java/edu/snu/cay/utils/TestLoggingConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.utils;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+/**
+ * Wrapper for logging config for debugging.
+ */
+public final class TestLoggingConfig {
+
+  public TestLoggingConfig() throws IOException {
+    LogManager.getLogManager().readConfiguration(
+        Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream("edu/snu/cay/utils/testlogging.properties"));
+  }
+}

--- a/utils/src/main/resources/edu/snu/cay/utils/testlogging.properties
+++ b/utils/src/main/resources/edu/snu/cay/utils/testlogging.properties
@@ -1,0 +1,80 @@
+# Copyright (C) 2016 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Properties file which configures the operation of the JDK
+# logging facility.
+# Heavily borrowed from REEF's logging.properties, and depends on REEF's ThreadLogFormatter.
+# For Cay developers, changing this configuration within Cay is much easier than changing REEF's configuration.
+
+# This config file should be redirected via the LoggingConfig class,
+# to ensure that it affects logs in all processes, even on different containers and hosts.
+# >java -Djava.util.logging.config.class=edu.snu.cay.utils.TestLoggingConfig
+
+# Make sure the updated logging.properties is available in the java classpath
+# (it might need to packaged into a jar)
+
+# Global logging properties.
+# ------------------------------------------
+# The set of handlers to be loaded upon startup.
+# Comma-separated list of class names.
+# (? LogManager docs say no comma here, but JDK example has comma.)
+# handlers=java.utils.logging.FileHandler, java.utils.logging.ConsoleHandler
+handlers=java.util.logging.ConsoleHandler
+
+# java.util.logging.SimpleFormatter.format=%1$tF %1$tT,%1$tL %4$s %2$s - %5$s%6$s%n
+
+org.apache.reef.util.logging.ThreadLogFormatter.format=%1$tF %1$tT,%1$tL %4$s %2$s %7$s | %5$s%6$s%n
+org.apache.reef.util.logging.ThreadLogFormatter.dropPrefix=org.apache.,edu.snu.
+
+# Default global logging level.
+# Loggers and Handlers may override this level
+# Change to ALL for debugging
+.level=ALL
+
+# Loggers
+# ------------------------------------------
+# Loggers are usually attached to packages.
+# Here, the level for each package is specified.
+# The global level is used by default, so levels
+# specified here simply act as an override.
+
+# org.apache.reef.examples.level=FINEST
+# org.apache.reef.tang.level=INFO
+
+# Handlers
+# -----------------------------------------
+
+# --- ConsoleHandler ---
+# Override of global logging level
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=org.apache.reef.util.logging.ThreadLogFormatter
+
+# --- FileHandler ---
+# Override of global logging level
+java.util.logging.FileHandler.level=ALL
+
+# Naming style for the output file:
+# (The output file is placed in the directory
+# defined by the "user.home" System property.)
+java.util.logging.FileHandler.pattern=%h/reef.%u.log
+
+# Limiting size of output file in bytes:
+java.util.logging.FileHandler.limit=512000
+
+# Number of output files to cycle through, by appending an
+# integer to the base file name:
+java.util.logging.FileHandler.count=100
+
+# Style of output (Simple or XML):
+java.util.logging.FileHandler.formatter=org.apache.reef.util.logging.ThreadLogFormatter


### PR DESCRIPTION
This PR changes the logging level of `ReconfigurationTest`, which is an integration test, to ALL for debugging.

We've observed that `ReconfigurationTest` occasionally failed in CI of Jenkins by an uncertain cause. But, since the apps run by Jenkins does not leave logs under INFO level, it's hard to find out the cause.

So this PR makes `ReconfigurationTest` log all level of loggings.
