### PR TITLE
[MINOR] Try releasing workers asynchronously on worker delete

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/SynchronizationManager.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/SynchronizationManager.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -131,7 +132,8 @@ final class SynchronizationManager {
 
     // when deleted worker did not send a sync msg yet
     } else {
-      tryReleaseWorkers();
+      // should be done asynchronously
+      Executors.newSingleThreadExecutor().execute(this::tryReleaseWorkers);
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in `SynchronizationManager`.

Its `onWorkerDeleted` method is called by `AsyncDolphinDriver` when an worker context has been closed by EM's Delete.

In the current implementation, this method is a blocking call and it tries releasing workers synchronously when workers are ready to be released by this Delete event. But, this releasing try may be blocked if there's ongoing optimization by EM.

Then `AsyncDolphinDriver`, a caller of the method, will be blocked while handling the closed context during EM's Delete. As a result, it causes a deadlock.

This PR fixes `onWorkerDeleted` to call `tryReleaseWorkers` asynchronously with a new thread.
