### PR TITLE
[MINOR] Lower the logging level in AddVectorWorker

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorWorker.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorWorker.java
@@ -119,7 +119,7 @@ final class AddVectorWorker implements Worker {
     for (int i = 0; i < numMiniBatchesPerItr; i++) {
       // 1. pull model to compute with
       final List<Vector> valueList = parameterWorker.pull(keyList);
-      LOG.log(Level.INFO, "Current values associated with keys {0} is {1}", new Object[]{keyList, valueList});
+      LOG.log(Level.FINE, "Current values associated with keys {0} is {1}", new Object[]{keyList, valueList});
 
       // 2. sleep to simulate computation
       try {
@@ -183,7 +183,7 @@ final class AddVectorWorker implements Worker {
     boolean isSuccess = true;
 
     final List<Vector> valueList = parameterWorker.pull(keyList);
-    LOG.log(Level.INFO, "Current values associated with keys {0} is {1}", new Object[]{keyList, valueList});
+    LOG.log(Level.FINE, "Current values associated with keys {0} is {1}", new Object[]{keyList, valueList});
 
     for (int idx = 0; idx < keyList.size(); idx++) {
       final int key = keyList.get(idx);


### PR DESCRIPTION
In AddVectorWorker, log messages for the values associated with each key are useful to understand current model. However, when the model is big and we have many iterations (i.e., `run()` is called in every iteration), the log will be filled with the messages. For example, I’ve run AddVector example using 20,000 vectors (NumKeys) of length 1000 with 4 workers, then the log message size was 1.6GB, most of which were printing the vectors.

I think `FINE` level would be enough for that log, as we already have a validation logic after all iterations are over. After lowering the level, I’ve confirmed that the log files became much smaller in a degree of 100KB as follows:

```
ubuntu@optiplex-7040-14:/tmp/add_vector_log$ ls -lrh
total 1.6G
-rw-rw-r-- 1 ubuntu ubuntu 1.6G Aug 11 13:08 before.log
-rw-rw-r-- 1 ubuntu ubuntu 129K Aug 11 13:07 after.log
```
