### PR TITLE
[MINOR] Double the retry time in testing PS worker

### DIFF
--- a/services/ps/src/test/java/edu/snu/cay/services/ps/worker/impl/ParameterWorkerTestUtil.java
+++ b/services/ps/src/test/java/edu/snu/cay/services/ps/worker/impl/ParameterWorkerTestUtil.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.verify;
  */
 public class ParameterWorkerTestUtil {
   public static final long CLOSE_TIMEOUT = 5000;
-  public static final long PULL_RETRY_TIMEOUT_MS = 500;
+  public static final long PULL_RETRY_TIMEOUT_MS = 1000;
   public static final String MSG_THREADS_SHOULD_FINISH = "threads not finished (possible deadlock or infinite loop)";
   private static final String MSG_THREADS_SHOULD_NOT_FINISH = "threads have finished but should not";
   private static final String MSG_RESULT_ASSERTION = "threads received incorrect values";


### PR DESCRIPTION
When testing PS worker, we set the retry time as 500 ms.
But in slow machines, this short retry time makes the test (testPullReject) fail.

So, this PR doubles the retry time to 1000 ms.
