### PR TITLE
[MINOR] Deregister a deleted server from EMRoutingTableManager

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
@@ -829,6 +829,9 @@ public final class AsyncDolphinDriver {
     } else if (deletedServerContextIds.remove(contextId)) {
       LOG.log(Level.INFO, "The server context {0} is closed by EM's Delete.", contextId);
 
+      // notify RoutingTableManager about the deletion of server
+      emRoutingTableManager.deregisterServer(contextId);
+
       if (!parentContext.isPresent()) {
         throw new RuntimeException("Root context of the deleted server context does not exist");
       }

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
@@ -15,6 +15,8 @@
  */
 package edu.snu.cay.services.ps.driver.impl;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import edu.snu.cay.services.em.driver.api.EMRoutingTableUpdate;
 import edu.snu.cay.services.em.driver.api.ElasticMemory;
 import edu.snu.cay.services.ps.avro.*;
@@ -42,7 +44,7 @@ public final class EMRoutingTableManager {
   /**
    * A mapping between store id and endpoint id of server-side evaluators.
    */
-  private final Map<Integer, String> storeIdToEndpointId = new HashMap<>();
+  private final BiMap<Integer, String> storeIdToEndpointId = HashBiMap.create();;
 
   /**
    * Server-side ElasticMemory instance.
@@ -103,13 +105,12 @@ public final class EMRoutingTableManager {
   }
 
   /**
-   * TODO #473: invoke this method when deleting memory store
    * Called when a Server instance based on EM is deleted.
    * This method cleans up existing metadata for the deleted server.
-   * @param storeId The MemoryStore id in EM.
+   * @param endpointId The Endpoint id in PS.
    */
-  public void deregisterServer(final int storeId) {
-    storeIdToEndpointId.remove(storeId);
+  public synchronized void deregisterServer(final String endpointId) {
+    storeIdToEndpointId.inverse().remove(endpointId);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a minor missing piece in `EMRoutingTableManager`.
With this PR, `EMRoutingTableManager` will not maintain the metadata of deleted servers.
