### PR TITLE
[MINOR] Synchronize all initial workers at the initial sync barrier

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/SynchronizationManager.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/SynchronizationManager.java
@@ -103,6 +103,8 @@ final class SynchronizationManager {
                                  final DataLoadingService dataLoadingService) {
     this.aggregationMaster = aggregationMaster;
     this.codec = codec;
+
+    // TODO #452: Decouple numWorkers from data input splits
     this.numInitialWorkers = dataLoadingService.getNumberOfPartitions();
     this.globalStateMachine = initStateMachine();
   }


### PR DESCRIPTION
This PR fixes a bug in integration of `ClockManager` and `SynchronizationManager`.

`ClockManager` assumes that `SynchronizationManager` synchronizes all initial workers at the initial barrier. But `SynchronizationManager` does not wait _too late_ initial workers and progress the step.

Due to this gap, when late workers are added to `ClockManager` the global clock has been already ticked by on-time workers, which passed the initial barrier leaving the late workers.

For this case, we've observed a test fail, which happens occasionally: `java.lang.RuntimeException: Initial worker WorkerContext-1 is added after global minimum clock changes`
