### PR TITLE
[MINOR] Use AsyncWorkerTask's iteration count in Trainer

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
@@ -87,7 +87,7 @@ final class AsyncWorkerTask implements Task {
         workerClock.recordClockNetworkWaitingTime();
         return null;
       }
-      trainer.run();
+      trainer.run(iteration);
       workerClock.clock();
     }
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
@@ -47,8 +47,10 @@ public interface Trainer {
   /**
    * Main method of this trainer. The number of times this method is called can be adjusted with the parameter
    * {@link edu.snu.cay.common.param.Parameters.Iterations}.
+   *
+   * @param iteration the index of current iteration
    */
-  void run();
+  void run(int iteration);
 
   /**
    * Post-run method executed after {@code run} but before task termination, exactly once.

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
@@ -49,8 +49,6 @@ final class NeuralNetworkTrainer implements Trainer {
   private final DataIdFactory<Long> idFactory;
   private final MemoryStore<Long> memoryStore;
 
-  private int iteration = 0;
-
   /**
    * @param dataParser the parser that transforms input data into {@link NeuralNetworkData} instances
    * @param neuralNetwork the neural network model
@@ -86,7 +84,7 @@ final class NeuralNetworkTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
+  public void run(final int iteration) {
     final Map<Long, NeuralNetworkData> workloadMap = memoryStore.getAll();
     final Collection<NeuralNetworkData> workload = workloadMap.values();
     final Collection<NeuralNetworkData> validationWorkload = Collections.emptyList();
@@ -119,7 +117,7 @@ final class NeuralNetworkTrainer implements Trainer {
     }
 
     LOG.log(Level.INFO, generateIterationLog(
-        trainingValidator.getValidationStats(), crossValidator.getValidationStats(), iteration++));
+        trainingValidator.getValidationStats(), crossValidator.getValidationStats(), iteration));
 
     crossValidator.getValidationStats().reset();
     trainingValidator.getValidationStats().reset();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
@@ -111,7 +111,7 @@ final class AddIntegerTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
+  public void run(final int iteration) {
     // sleep to simulate computation
     computeTracer.startTimer();
     try {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -91,11 +91,6 @@ final class AddVectorTrainer implements Trainer {
   private final Tracer pullTracer;
   private final Tracer computeTracer;
 
-  /**
-   * Number of iterations.
-   */
-  private int iteration = 0;
-
   @Inject
   private AddVectorTrainer(final ParameterWorker<Integer, Integer, Vector> parameterWorker,
                            @Parameter(AddVectorREEF.DeltaValue.class) final int delta,
@@ -134,8 +129,7 @@ final class AddVectorTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
-    ++iteration;
+  public void run(final int iteration) {
     final long iterationBegin = System.currentTimeMillis();
     resetTracers();
 
@@ -168,7 +162,7 @@ final class AddVectorTrainer implements Trainer {
     final double elapsedTime = (System.currentTimeMillis() - iterationBegin) / 1000.0D;
     // send empty metrics to trigger optimization
     final WorkerMetrics workerMetrics =
-        buildMetricsMsg(memoryStore.getNumBlocks(), elapsedTime);
+        buildMetricsMsg(iteration, memoryStore.getNumBlocks(), elapsedTime);
 
     LOG.log(Level.INFO, "WorkerMetrics {0}", workerMetrics);
     sendMetrics(workerMetrics);
@@ -180,7 +174,7 @@ final class AddVectorTrainer implements Trainer {
     metricsMsgSender.send(workerMetrics);
   }
 
-  private WorkerMetrics buildMetricsMsg(final int numDataBlocks, final double elapsedTime) {
+  private WorkerMetrics buildMetricsMsg(final int iteration, final int numDataBlocks, final double elapsedTime) {
     return WorkerMetrics.newBuilder()
         .setItrIdx(iteration)
         .setNumMiniBatchPerItr(numMiniBatchesPerItr)

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
@@ -138,7 +138,7 @@ final class LassoTrainer implements Trainer {
    * 4) Push value to server.
    */
   @Override
-  public void run() {
+  public void run(final int iteration) {
     final double[] vecModel = new double[vecXArray.length];
     for (int index = 0; index < vecModel.length; index++) {
       vecModel[index] = parameterWorker.pull(index);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LdaTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LdaTrainer.java
@@ -87,7 +87,7 @@ final class LdaTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
+  public void run(final int iteration) {
     LOG.log(Level.INFO, "Iteration Started");
 
     final Map<Long, Document> workloadMap = memoryStore.getAll();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -106,11 +106,6 @@ final class MLRTrainer implements Trainer {
   private List<Integer> classPartitionIndices;
 
   /**
-   * Number of times {@code run()} has been called.
-   */
-  private int iteration;
-
-  /**
    * The step size drops by this rate.
    */
   private final double decayRate;
@@ -164,7 +159,6 @@ final class MLRTrainer implements Trainer {
     this.vectorFactory = vectorFactory;
     this.oldModels = new Vector[numClasses];
     this.newModels = new Vector[numClasses];
-    this.iteration = 0;
     this.decayRate = decayRate;
     this.decayPeriod = decayPeriod;
     this.trainErrorDatasetSize = trainErrorDatasetSize;
@@ -214,8 +208,7 @@ final class MLRTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
-    ++iteration;
+  public void run(final int iteration) {
     final long iterationBegin = System.currentTimeMillis();
     resetTracers();
 
@@ -292,7 +285,7 @@ final class MLRTrainer implements Trainer {
     final Metrics appMetrics = buildAppMetrics(lossRegLossAccuracy.getFirst(),
         lossRegLossAccuracy.getSecond(), (double) lossRegLossAccuracy.getThird(), elapsedTime, numInstances);
     final WorkerMetrics workerMetrics =
-        buildMetricsMsg(appMetrics, numEMBlocks, workload.size(), elapsedTime);
+        buildMetricsMsg(iteration, appMetrics, numEMBlocks, workload.size(), elapsedTime);
 
     LOG.log(Level.INFO, "WorkerMetrics {0}", workerMetrics);
     sendMetrics(workerMetrics);
@@ -463,7 +456,7 @@ final class MLRTrainer implements Trainer {
     metricsMsgSender.send(workerMetrics);
   }
 
-  private WorkerMetrics buildMetricsMsg(final Metrics appMetrics, final int numDataBlocks,
+  private WorkerMetrics buildMetricsMsg(final int iteration, final Metrics appMetrics, final int numDataBlocks,
                                         final int numProcessedDataItemCount, final double elapsedTime) {
     final WorkerMetrics workerMetrics = WorkerMetrics.newBuilder()
         .setMetrics(appMetrics)

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -76,11 +76,6 @@ final class NMFTrainer implements Trainer {
   private final Tracer pullTracer;
   private final Tracer computeTracer;
 
-  /**
-   * Number of iterations.
-   */
-  private int iteration = 0;
-
   @Inject
   private NMFTrainer(final NMFDataParser dataParser,
                      final ParameterWorker<Integer, Vector, Vector> parameterWorker,
@@ -135,8 +130,7 @@ final class NMFTrainer implements Trainer {
   }
 
   @Override
-  public void run() {
-    ++iteration;
+  public void run(final int iteration) {
     final long iterationBegin = System.currentTimeMillis();
     double lossSum = 0.0;
     int elemCount = 0;
@@ -221,7 +215,7 @@ final class NMFTrainer implements Trainer {
     final double elapsedTime = (System.currentTimeMillis() - iterationBegin) / 1000.0D;
     final Metrics appMetrics = buildAppMetrics(lossSum, elemCount, elapsedTime, workload.size());
     final WorkerMetrics workerMetrics =
-        buildMetricsMsg(appMetrics, numEMBlocks, workload.size(), elapsedTime);
+        buildMetricsMsg(iteration, appMetrics, numEMBlocks, workload.size(), elapsedTime);
 
     LOG.log(Level.INFO, "WorkerMetrics {0}", workerMetrics);
     sendMetrics(workerMetrics);
@@ -330,7 +324,7 @@ final class NMFTrainer implements Trainer {
     metricsMsgSender.send(workerMetrics);
   }
 
-  private WorkerMetrics buildMetricsMsg(final Metrics appMetrics, final int numDataBlocks,
+  private WorkerMetrics buildMetricsMsg(final int iteration, final Metrics appMetrics, final int numDataBlocks,
                                         final int numProcessedDataItemCount, final double elapsedTime) {
     return WorkerMetrics.newBuilder()
         .setMetrics(appMetrics)


### PR DESCRIPTION
Currently, `AsyncWorkerTask` and `Trainer` count iteration index separately.
It has been worked well. But by introducing #748, workers may start their iteration from non-zero value. So in #748 we changed `AsyncWorkerTask` to use this dynamically determined value, but `Trainer` still counts its own iteration idx from zero.

To eliminate this gap, this PR changes `Trainer` interface to merge these distinct counters into one maintained by `AsyncWorkerTask`.

From now, `Trainer` receives the current iteration count through `Trainer.run(int iteration)` method called by `AsyncWorkerTask`.
