### PR TITLE
[MINOR] Catch and log RuntimeException in PS worker threads

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
@@ -757,6 +757,9 @@ public final class AsyncParameterWorker<K, P, V> implements ParameterWorker<K, P
         }
 
         finishClose();
+
+      // catch and rethrow RuntimeException after leaving a log
+      // otherwise, the thread disappears without any noticeable marks
       } catch (final RuntimeException e) {
         LOG.log(Level.SEVERE, "PS worker thread has been down due to RuntimeException", e);
         throw e;

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/SSPParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/SSPParameterWorker.java
@@ -796,6 +796,9 @@ public final class SSPParameterWorker<K, P, V> implements ParameterWorker<K, P, 
         }
 
         finishClose();
+
+      // catch and rethrow RuntimeException after leaving a log
+      // otherwise, the thread disapperas without any noticeable marks
       } catch (final RuntimeException e) {
         LOG.log(Level.SEVERE, "PS worker thread has been down due to RuntimeException", e);
         throw e;


### PR DESCRIPTION
Currently, `RuntimeException`s thrown in PS worker threads are not caught properly. As a result, these threads has been killed without any noticeable logs.

To resolve it, this PR wraps the body of `run()` method in WorkerThread with `try{}` followed by `catch (RuntimeException) {}`.

From now on, all thread workers will be dead, after leaving an explicit log.
