### PR TITLE
[MINOR] Print more information about cost estimation for analysis

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
@@ -162,7 +162,7 @@ public final class AsyncDolphinOptimizer implements Optimizer {
         .mapToDouble(param -> ((WorkerMetrics) param.getMetrics()).getTotalPullTime()).average().orElse(0D);
 
     final String optimizationInfo = String.format("{\"numAvailEval\":%d, " +
-            "\"currNumWorker\":%d, \"currNumServer\":%d, \"optNumWorker\":%d, \"optNumServer\":%d, " +
+            "\"optNumWorker\":%d, \"currNumWorker\":%d, \"optNumServer\":%d, \"currNumServer\":%d, " +
             "\"optCompCost\":%f, \"currCompCost\":%f, \"optCommCost\":%f, \"currCommCost\":%f," +
             "\"optBenefitThreshold\":%f}", availableEvaluators,
         currentNumWorkers, currentNumServers, optimalNumWorkers, optimalNumServers,
@@ -313,15 +313,15 @@ public final class AsyncDolphinOptimizer implements Optimizer {
     final double compCost = numDataBlocks / workerThroughputSum;
 
     // Calculating commCost based on avg: (avgNumBlockPerServer / avgThroughput)
-    final int numServers = availableEvaluators - numWorker;
-    final double serverThroughputSum = servers.subList(0, numServers).stream()
+    final int numServer = availableEvaluators - numWorker;
+    final double serverThroughputSum = servers.subList(0, numServer).stream()
         .mapToDouble(server -> server.throughput)
         .sum();
     final double commCost = numModelBlocks / serverThroughputSum * numWorker * numMiniBatchPerItr;
     final double totalCost = compCost + commCost;
-    LOG.log(Level.INFO, "Estimated Cost: (server, worker) = ({0}, {1}), totalCost = {2}, " +
-        "(compCost, commCost) = ({3}, {4})",
-        new Object[] {numServers, numWorker, totalCost, compCost, commCost});
+    final String costInfo = String.format("{\"numServer\": %d, \"numWorker\": %d, \"totalCost\": %f, " +
+        "\"compCost\": %f, \"commCost\": %f}", numServer, numWorker, totalCost, compCost, commCost);
+    LOG.log(Level.INFO, "CostInfo {0} {1}", new Object[]{System.currentTimeMillis(), costInfo});
     return new Pair<>(compCost, commCost);
   }
 


### PR DESCRIPTION
By #795 we provide additional information regarding the optimal cost as follows:

```
INFO: OptimizationInfo 1,473,030,456,619 {"numAvailEval":10, "numOptWorker":4,  "numOptServer":6, "optimalCompCost":108.283414, "currentCompCost":49.234111, "optimalCommCost":63.453904, "currrentCommCost":37.012778, "optBenefitThreshold":0.100000}
```

However, to evaluate our optimizer's cost model, it'd be great to see how the cost is computed in other configurations as well. For example, with the changes in this PR, the logs consist of following results:

```
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (9, 1), totalCost = 430.389, (compCost, commCost) = (419.813, 10.576)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (8, 2), totalCost = 235.337, (compCost, commCost) = (211.542, 23.795)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (7, 3), totalCost = 183.8, (compCost, commCost) = (143.009, 40.792)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (6, 4), totalCost = 171.737, (compCost, commCost) = (108.283, 63.454)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (5, 5), totalCost = 182.341, (compCost, commCost) = (87.161, 95.181)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (4, 6), totalCost = 215.752, (compCost, commCost) = (72.981, 142.771)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (3, 7), totalCost = 284.926, (compCost, commCost) = (62.837, 222.089)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (2, 8), totalCost = 435.897, (compCost, commCost) = (55.173, 380.723)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer totalCost
INFO: Estimated Cost: (server, worker) = (1, 9), totalCost = 905.83, (compCost, commCost) = (49.202, 856.628)
Sep 04, 2016 11:07:36 PM edu.snu.cay.dolphin.async.optimizer.AsyncDolphinOptimizer optimize
INFO: OptimizationInfo 1,473,030,456,619 {"numAvailEval":10, "currNumWorker":9, "currNumServer":1, "optNumWorker":4, "optNumServer":6, "optCompCost":108.283414, "currCompCost":49.234111, "optCommCost":63.453904, "currCommCost":37.012778,"optBenefitThreshold":0.100000}
```

I believe this information will ease us when we validate our cost model with the ground truth.
