### PR TITLE
[MINOR] Make driver memory configurable

### DIFF
--- a/common/src/main/java/edu/snu/cay/common/param/Parameters.java
+++ b/common/src/main/java/edu/snu/cay/common/param/Parameters.java
@@ -22,6 +22,11 @@ import org.apache.reef.tang.annotations.NamedParameter;
  * Common parameter classes for application frameworks.
  */
 public final class Parameters {
+  @NamedParameter(doc = "Desired memory size for the driver (MBs)",
+                  short_name = "driver_memory",
+                  default_value = "256")
+  public final class DriverMemory implements Name<Integer> {
+  }
 
   @NamedParameter(doc = "Desired memory size for each evaluator (MBs)",
                   short_name = "eval_size",

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
@@ -257,6 +257,7 @@ public final class AsyncDolphinLauncher {
     // add all basic parameters
     // TODO #681: Need to add configuration for numWorkerThreads after multi-thread worker is enabled
     final List<Class<? extends Name<?>>> basicParameterClassList = new LinkedList<>();
+    basicParameterClassList.add(DriverMemory.class);
     basicParameterClassList.add(EvaluatorSize.class);
     basicParameterClassList.add(InputDir.class);
     basicParameterClassList.add(OnLocal.class);
@@ -356,6 +357,7 @@ public final class AsyncDolphinLauncher {
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(AsyncDolphinDriver.class))
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(TextInputFormat.class))
         .set(DriverConfiguration.DRIVER_IDENTIFIER, jobName)
+        .set(DriverConfiguration.DRIVER_MEMORY, injector.getNamedInstance(DriverMemory.class))
         .set(DriverConfiguration.ON_DRIVER_STARTED, AsyncDolphinDriver.StartHandler.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, AsyncDolphinDriver.AllocatedEvaluatorHandler.class)
         .set(DriverConfiguration.ON_EVALUATOR_FAILED, AsyncDolphinDriver.FailedEvaluatorHandler.class)


### PR DESCRIPTION
This PR adds a parameter to make the memory size be configurable. By adding this, we can enforce the locality constraint in YARN, which is not fully supported by REEF on YARN yet. As a workaround, we can set the node manager's memory capacity differently, of the machine where we want to run the driver.
