### PR TITLE
[MINOR] Reorder arguments in log message for cost analysis

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
@@ -165,7 +165,7 @@ public final class AsyncDolphinOptimizer implements Optimizer {
             "\"optNumWorker\":%d, \"currNumWorker\":%d, \"optNumServer\":%d, \"currNumServer\":%d, " +
             "\"optCompCost\":%f, \"currCompCost\":%f, \"optCommCost\":%f, \"currCommCost\":%f," +
             "\"optBenefitThreshold\":%f}", availableEvaluators,
-        currentNumWorkers, currentNumServers, optimalNumWorkers, optimalNumServers,
+        optimalNumWorkers, currentNumWorkers, optimalNumServers, currentNumServers,
         optimalCompCost, currentCompCost, optimalCommCost, currentCommCost, optBenefitThreshold);
 
     LOG.log(Level.INFO, "OptimizationInfo {0} {1}", new Object[]{System.currentTimeMillis(), optimizationInfo});


### PR DESCRIPTION
In #801 I changed the order of arguments in log message at the last moment, but I missed to apply the change at the object array. This PR addresses the inconsistency in the message arguments.
