### PR TITLE
[MINOR] Add a missing break in worker-side msg handler

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/WorkerSideMsgHandler.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/WorkerSideMsgHandler.java
@@ -107,6 +107,7 @@ public final class WorkerSideMsgHandler<K, P, V> implements EventHandler<Message
 
     case RoutingTableSyncMsg:
       onRoutingTableSyncMsg(innerMsg.getRoutingTableSyncMsg());
+      break;
 
     default:
       throw new RuntimeException("Unexpected message type: " + innerMsg.getType().toString());


### PR DESCRIPTION
This PR fixes a bug when handling `RoutingTableSyncMsg` introduced in #751.
