### PR TITLE
[MINOR] Change resolver's checkInitialization() to be safe from frequent thread interrupts

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/common/resolver/DynamicServerResolver.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/common/resolver/DynamicServerResolver.java
@@ -89,6 +89,7 @@ public final class DynamicServerResolver implements ServerResolver {
    * otherwise waits the initialization within a bounded time.
    */
   private void checkInitialization() {
+    boolean interrupted = false;
     while (true) {
       if (initLatch.getCount() == 0) {
         break;
@@ -98,8 +99,13 @@ public final class DynamicServerResolver implements ServerResolver {
         initLatch.await();
         break;
       } catch (final InterruptedException e) {
+        interrupted = true;
         LOG.log(Level.WARNING, "Interrupted while waiting for routing table initialization from driver", e);
       }
+    }
+    // restore thread interrupt state
+    if (interrupted) {
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
By #799, PS worker threads may get interrupts due to retry and reject of pull op.
Because of this change, worker threads may have problem when invoking`DynamicServerResolver.resolverServer()` that internally calls `DynamicServerResolver.checkInitialization()`. This method waits initialization using `CountDownLatch.await()`. The problem is that this way never successfully return and keeps throwing `InterruptException`, when there are frequent thread interrupts.
So this PR adds an additional way of checking initialization using `CountDownLatch.getCount()`.
