### PR TITLE
[MINOR] Configure Htrace in PSExample to avoid a Tang exception

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/PSExampleREEF.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/examples/add/PSExampleREEF.java
@@ -23,6 +23,7 @@ import edu.snu.cay.services.ps.common.parameters.NumPartitions;
 import edu.snu.cay.services.ps.server.parameters.ServerNumThreads;
 import edu.snu.cay.services.ps.server.parameters.ServerQueueSize;
 import edu.snu.cay.services.ps.worker.parameters.*;
+import edu.snu.cay.utils.trace.HTraceParameters;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
@@ -138,7 +139,9 @@ public final class PSExampleREEF {
         .setValueCodecClass(IntegerCodec.class)
         .build();
 
-    return Configurations.merge(driverConf, parametersConf, psConf);
+    final Configuration traceConf = HTraceParameters.getStaticConfiguration();
+
+    return Configurations.merge(driverConf, parametersConf, psConf, traceConf);
   }
 
   private Configuration getRuntimeConfiguration() {
@@ -173,6 +176,7 @@ public final class PSExampleREEF {
     cl.registerShortNameOfClass(PullRetryTimeoutMs.class);
     cl.registerShortNameOfClass(MaxPendingPullsPerThread.class);
     cl.registerShortNameOfClass(WorkerKeyCacheSize.class);
+    HTraceParameters.registerShortNames(cl);
 
     cl.processCommandLine(args);
 


### PR DESCRIPTION
In #817, we've installed Htrace on PS, but did not bind trace configuration in PS example app, because it uses the static version of PS.

However I found that static PS requires trace configurations, because static PS also uses `AsyncParameterWorker`, which is the common component for both dynamic and static PS. Without the trace configuration, it throws _no implementation_ exception by Tang.

So this PR provides trace configuration using `HtraceParameters`.

Note that this PR does not enable HTrace on this app. It just provides configurations related to Htrace that actually has no effect.
