### PR TITLE
[MINOR] Fix closing logic of ParameterWorker's RetryThread

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
@@ -1235,8 +1235,7 @@ public final class AsyncParameterWorker<K, P, V> implements ParameterWorker<K, P
           } catch (final InterruptedException e) {
             // interrupt on this thread is always requested by startClose()
             if (stateMachine.getCurrentState().equals(STATE_CLOSING)) {
-              finishClose();
-              return;
+              break;
             } else {
               throw new RuntimeException(e);
             }


### PR DESCRIPTION
This fixes the closing logic of `RetryThread`.
If we choose value of `PullRetryTimeoutMs` a lot greater than `NetworkContextRegister.CLOSE_TIMEOUT_MS`, the `RetryThread` never gets notification of close event because it is sleeping. This PR fixes this issue by interrupting the `RetryThread` when parameter worker is requested to be closed.
