### PR TITLE
[MINOR] Include ParameterWorker metrics in the example apps

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
@@ -147,6 +147,7 @@ final class AddIntegerTrainer implements Trainer {
     return WorkerMetrics.newBuilder()
         .setNumDataBlocks(numDataBlocks)
         .setTotalCompTime(computeTracer.totalElapsedTime())
+        .setParameterWorkerMetrics(parameterWorker.buildParameterWorkerMetrics())
         .build();
   }
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -186,6 +186,7 @@ final class AddVectorTrainer implements Trainer {
         .setAvgPullTime(pullTracer.avgTimePerRecord())
         .setTotalPushTime(pushTracer.totalElapsedTime())
         .setAvgPushTime(pushTracer.avgTimePerRecord())
+        .setParameterWorkerMetrics(parameterWorker.buildParameterWorkerMetrics())
         .build();
   }
 


### PR DESCRIPTION
In _AddVector_ and _AddInteger_ examples, Trainer omits the metrics from ParameterWorker, which is useful for performance investigation. This PR adds the missing metrics to the examples.
