### PR TITLE
[MINOR] Fix bugs in codecs in async dolphin module

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/data/MatrixCodec.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/data/MatrixCodec.java
@@ -29,8 +29,6 @@ import java.io.*;
  * Implements the {@code StreamingCodec} interface for efficient usages in other codec classes.
  */
 public final class MatrixCodec implements StreamingCodec<Matrix> {
-  private static final int INTEGER_BYTES = 4; // size of integer in bytes
-  private static final int FLOAT_BYTES = 4; // size of float in bytes
 
   private final MatrixFactory matrixFactory;
 
@@ -45,8 +43,8 @@ public final class MatrixCodec implements StreamingCodec<Matrix> {
 
   @Override
   public byte[] encode(final Matrix matrix) {
-    try (final ByteArrayOutputStream bstream = new ByteArrayOutputStream(INTEGER_BYTES * 2 +
-                                                                         FLOAT_BYTES * matrix.getLength());
+    try (final ByteArrayOutputStream bstream = new ByteArrayOutputStream(Integer.BYTES * 2 +
+                                                                         Float.BYTES * matrix.getLength());
          final DataOutputStream dstream = new DataOutputStream(bstream)) {
 
       encodeToStream(matrix, dstream);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRDataSerializer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRDataSerializer.java
@@ -29,8 +29,6 @@ import java.io.*;
  * Serializer that provides codec for (de-)serializing data used in MLR.
  */
 final class MLRDataSerializer implements Serializer {
-  private static final int INTEGER_BYTES = 4; // size of integer in bytes
-
   private final SparseVectorCodec sparseVectorCodec;
   private final MLRDataCodec mlrDataCodec = new MLRDataCodec();
 
@@ -47,7 +45,7 @@ final class MLRDataSerializer implements Serializer {
   private final class MLRDataCodec implements Codec<Pair<Vector, Integer>>, StreamingCodec<Pair<Vector, Integer>> {
     @Override
     public byte[] encode(final Pair<Vector, Integer> mlrData) {
-      final int numBytes = sparseVectorCodec.getNumBytes(mlrData.getFirst()) + INTEGER_BYTES;
+      final int numBytes = sparseVectorCodec.getNumBytes(mlrData.getFirst()) + Integer.BYTES;
       try (final ByteArrayOutputStream baos = new ByteArrayOutputStream(numBytes);
            final DataOutputStream daos = new DataOutputStream(baos)) {
         encodeToStream(mlrData, daos);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFDataSerializer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFDataSerializer.java
@@ -31,9 +31,6 @@ import java.util.List;
  * Serializer that provides codec for (de-)serializing data used in NMF.
  */
 final class NMFDataSerializer implements Serializer {
-  private static final int INTEGER_BYTES = 4; // size of integer in bytes
-  private static final int DOUBLE_BYTES = 8; // size of double in bytes
-
   private final DenseVectorCodec denseVectorCodec;
   private final NMFDataCodec nmfDataCodec = new NMFDataCodec();
 
@@ -51,7 +48,7 @@ final class NMFDataSerializer implements Serializer {
     @Override
     public byte[] encode(final NMFData nmfData) {
       final int numBytes =
-          denseVectorCodec.getNumBytes(nmfData.getVector()) + getNumBytes(nmfData.getColumns()) + INTEGER_BYTES;
+          denseVectorCodec.getNumBytes(nmfData.getVector()) + getNumBytes(nmfData.getColumns()) + Integer.BYTES;
       try (final ByteArrayOutputStream baos = new ByteArrayOutputStream(numBytes);
            final DataOutputStream daos = new DataOutputStream(baos)) {
         encodeToStream(nmfData, daos);
@@ -100,7 +97,7 @@ final class NMFDataSerializer implements Serializer {
    * @return the total number of bytes of the encoded columns
    */
   private int getNumBytes(final List<Pair<Integer, Double>> columns) {
-    return INTEGER_BYTES + columns.size() * (INTEGER_BYTES + DOUBLE_BYTES);
+    return Integer.BYTES + columns.size() * (Integer.BYTES + Double.BYTES);
   }
 
   private void encodeColumns(final List<Pair<Integer, Double>> columns,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/serialization/DenseVectorCodec.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/serialization/DenseVectorCodec.java
@@ -29,9 +29,6 @@ import java.util.logging.Logger;
  */
 public final class DenseVectorCodec implements Codec<Vector>, StreamingCodec<Vector> {
   private static final Logger LOG = Logger.getLogger(DenseVectorCodec.class.getName());
-  private static final int INTEGER_BYTES = 4; // size of integer in bytes
-  private static final int DOUBLE_BYTES = 8; // size of double in bytes
-
   private final VectorFactory vectorFactory;
 
   @Inject
@@ -93,6 +90,6 @@ public final class DenseVectorCodec implements Codec<Vector>, StreamingCodec<Vec
     if (!vector.isDense()) {
       LOG.warning("the given vector is not dense.");
     }
-    return INTEGER_BYTES + DOUBLE_BYTES * vector.length();
+    return Integer.BYTES + Double.BYTES * vector.length();
   }
 }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/serialization/SparseVectorCodec.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/serialization/SparseVectorCodec.java
@@ -30,9 +30,6 @@ import java.util.logging.Logger;
  */
 public final class SparseVectorCodec implements Codec<Vector>, StreamingCodec<Vector> {
   private static final Logger LOG = Logger.getLogger(SparseVectorCodec.class.getName());
-  private static final int INTEGER_BYTES = 4; // size of integer in bytes
-  private static final int DOUBLE_BYTES = 8; // size of double in bytes
-
   private final VectorFactory vectorFactory;
 
   @Inject
@@ -99,6 +96,6 @@ public final class SparseVectorCodec implements Codec<Vector>, StreamingCodec<Ve
     if (vector.isDense()) {
       LOG.warning("the given vector is not sparse.");
     }
-    return 2 * INTEGER_BYTES + (INTEGER_BYTES + DOUBLE_BYTES) * vector.activeSize();
+    return 2 * Integer.BYTES + (Integer.BYTES + Double.BYTES) * vector.activeSize();
   }
 }


### PR DESCRIPTION
We used `Integer.SIZE` for allocating memory space in terms of bytes for encoding an integer. However, `Integer.SIZE` is the number of bits for an integer, which is 4 times greater than the number of bytes. Similar bugs exists for encoding float and double. This PR fixes these bugs in codecs in async dolphin module.
