### PR TITLE
[MINOR] Introduce run_all.sh in DolphinAsync

### DIFF
--- a/dolphin/async/bin/run_all.sh
+++ b/dolphin/async/bin/run_all.sh
@@ -16,7 +16,7 @@
 # Launch all run_FOO.sh scripts with the example usage command
 for file in run*.sh;
 do
-	if [[ "$0" != *"$file" ]]
+  if [[ "$0" != *"$file" ]]
   then
     echo "*** Execute $file ***"
     cmd="grep 'run_' $file | sed 's/# //g'"


### PR DESCRIPTION
This PR adds a script for running all `run_foo.sh` scripts in `dolphin/async/bin` directory. With this script, we can execute all the examples with only one command, without having to copy & paste example usage. 

We can later make our CI run this script not to forget running examples for integration tests.
