### PR TITLE
[MINOR] Fix bug while handling lda minibatch and minor refactor

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
@@ -53,7 +53,7 @@ final class SparseLDASampler {
     this.batchParameterWorker = batchParameterWorker;
   }
 
-  void sample(final List<Document> documents, final Tracer computeTracer,
+  void sample(final Collection<Document> documents, final Tracer computeTracer,
               final Tracer pushTracer, final Tracer pullTracer) {
     computeTracer.startTimer();
     final List<Integer> words = getKeys(documents);


### PR DESCRIPTION
This patch includes the followings:
- fix a bug while handling mini-batch workload given by `TrainingDataProvider`
- minor refactoring to avoid redundant array allocation
- add log before pulling model to compute LLH
