### PR TITLE
[MINOR] Fix LDA to push only once in a minibatch

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
@@ -188,9 +188,8 @@ final class SparseLDASampler {
         }
       }
       computeTracer.recordTime(1);
-
-      batchParameterWorker.pushAndClear(computeTracer, pushTracer);
     }
+    batchParameterWorker.pushAndClear(computeTracer, pushTracer);
   }
 
   private List<Integer> getKeys(final Collection<Document> documents) {


### PR DESCRIPTION
This PR fixes `SparseLDASampler` to push only once in a minibatch, to make it trains faster.
- The patch significantly decreases the cost for push per epoch; _totalPushTime_ become less than 5% of the one before.
- Not only push, but also pull time decreases (because pull operations' waiting time in the queue decreases); _totalPullTime_ become 50~60% of the one before.
- Convergence per epoch is almost the same (~1%) as before.

Please refer to the figure below. The experiments used NYTimes dataset, with 2 servers, 5000 minibatch size, 6 epochs.
![image](https://cloud.githubusercontent.com/assets/10707460/18868956/0b0db472-84e5-11e6-8009-aaefe71727eb.png)
