### PR TITLE
[MINOR] Fix the data type of received/sent bytes to long

### DIFF
--- a/services/ps/src/main/avro/parameterserver.avsc
+++ b/services/ps/src/main/avro/parameterserver.avsc
@@ -263,13 +263,13 @@
     {"name": "totalSentBytesStatCount", "type": "int", "default": 0},
 
     // number of data in bytes sent by push
-    {"name": "totalSentBytes", "type": "int", "default": 0},
+    {"name": "totalSentBytes", "type": "long", "default": 0},
 
     // number of events of receiving bytes by pull
     {"name": "totalReceivedBytesStatCount", "type": "int", "default": 0},
 
     // number of data in bytes received by pull
-    {"name": "totalReceivedBytes", "type": "int", "default": 0}
+    {"name": "totalReceivedBytes", "type": "long", "default": 0}
   ]
 },
 

--- a/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/worker/impl/AsyncParameterWorker.java
@@ -556,9 +556,9 @@ public final class AsyncParameterWorker<K, P, V> implements ParameterWorker<K, P
         .setTotalNetworkTimeSec(totalNetworkStat.getRight() / 1e9D)
         .setTotalWaitingStatCount(totalWaitingStat.getLeft())
         .setTotalWaitingTimeSec(totalWaitingStat.getRight() / 1e9D)
-        .setTotalSentBytes(totalSentBytesStat.getRight().intValue())
+        .setTotalSentBytes(totalSentBytesStat.getRight().longValue())
         .setTotalSentBytesStatCount(totalSentBytesStat.getLeft())
-        .setTotalReceivedBytes(totalReceivedBytesStat.getRight().intValue())
+        .setTotalReceivedBytes(totalReceivedBytesStat.getRight().longValue())
         .setTotalReceivedBytesStatCount(totalReceivedBytesStat.getLeft())
         .build();
   }


### PR DESCRIPTION
This PR changes the data type of byte stats to `long` to prevent overflow. Thanks @gyeongin to report this.
