### PR TITLE
[MINOR] Cleanup worker metrics in algorithms

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -192,9 +192,9 @@ final class AddVectorTrainer implements Trainer {
         .setTotalTime(elapsedTime)
         .setTotalCompTime(computeTracer.totalElapsedTime())
         .setTotalPullTime(pullTracer.totalElapsedTime())
-        .setAvgPullTime(pullTracer.avgTimePerRecord())
+        .setAvgPullTime(pullTracer.avgTimePerElem())
         .setTotalPushTime(pushTracer.totalElapsedTime())
-        .setAvgPushTime(pushTracer.avgTimePerRecord())
+        .setAvgPushTime(pushTracer.avgTimePerElem())
         .setParameterWorkerMetrics(parameterWorker.buildParameterWorkerMetrics())
         .build();
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/Tracer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/Tracer.java
@@ -61,7 +61,7 @@ public class Tracer {
    * @return total elapsed time in seconds.
    */
   public double totalElapsedTime() {
-    return sum / 1000.0D;
+    return (double) sum / 1000D;
   }
 
   /**
@@ -73,7 +73,7 @@ public class Tracer {
       return Double.POSITIVE_INFINITY;
     }
 
-    return sum / count / 1000.0D;
+    return (double) sum / count / 1000D;
   }
 
   /**
@@ -85,6 +85,6 @@ public class Tracer {
       return Double.POSITIVE_INFINITY;
     }
 
-    return sum / elemCount / 1000.0D;
+    return (double) sum / elemCount / 1000D;
   }
 }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDAParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDAParameters.java
@@ -50,5 +50,10 @@ final class LDAParameters {
     // The key denoting a portion of log likelihood (P(w|z)) computed from word-topic distribution.
     static final String WORD_LLH =
         "LDA_TRAINER_WORD_LLH";
+
+    // The key denoting the number of training data instances processed per unit time.
+    static final String DVT =
+        "LDA_TRAINER_DVT";
+
   }
 }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
@@ -205,7 +205,13 @@ final class LDATrainer implements Trainer {
 
   private WorkerMetrics buildMiniBatchMetric(final int iteration, final int miniBatchIdx,
                                              final int numProcessedDataItemCount, final double elapsedTime) {
-    final WorkerMetrics workerMetrics = WorkerMetrics.newBuilder()
+    final Map<CharSequence, Double> appMetricMap = new HashMap<>();
+    appMetricMap.put(MetricKeys.DVT, numProcessedDataItemCount / elapsedTime);
+
+    return WorkerMetrics.newBuilder()
+        .setMetrics(Metrics.newBuilder()
+            .setData(appMetricMap)
+            .build())
         .setEpochIdx(iteration)
         .setMiniBatchSize(miniBatchSize)
         .setMiniBatchIdx(miniBatchIdx)
@@ -218,8 +224,6 @@ final class LDATrainer implements Trainer {
         .setAvgPushTime(pushTracer.avgTimePerElem())
         .setParameterWorkerMetrics(parameterWorker.buildParameterWorkerMetrics())
         .build();
-
-    return workerMetrics;
   }
 
   private WorkerMetrics buildEpochMetric(final int iteration, final int numMiniBatchForEpoch,
@@ -229,6 +233,7 @@ final class LDATrainer implements Trainer {
     final Map<CharSequence, Double> appMetricMap = new HashMap<>();
     appMetricMap.put(MetricKeys.DOC_LLH, docLLH);
     appMetricMap.put(MetricKeys.WORD_LLH, wordLLH);
+    parameterWorker.buildParameterWorkerMetrics(); // clear ParameterWorker metrics
 
     return WorkerMetrics.newBuilder()
         .setMetrics(Metrics.newBuilder()

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRParameters.java
@@ -62,9 +62,9 @@ final class MLRParameters {
 
   static final class MetricKeys {
 
-    // The key denoting the average of loss computed from the sample of training data instances.
-    static final String SAMPLE_LOSS_AVG =
-        "MLR_TRAINER_SAMPLE_LOSS_AVG";
+    // The key denoting the sum of loss computed from the sample of training data instances.
+    static final String SAMPLE_LOSS_SUM =
+        "MLR_TRAINER_SAMPLE_LOSS_SUM";
 
     // The key denoting the average of L2-regularized loss computed from the sample of training data instances.
     static final String REG_LOSS_AVG =

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFParameters.java
@@ -53,20 +53,12 @@ final class NMFParameters {
   }
 
   static final class MetricKeys {
-    // The key denoting the average of loss computed from training data instances.
-    static final String AVG_LOSS =
-        "NMF_TRAINER_AVG_LOSS";
-
     // The key denoting the total loss computed from training data instances.
     static final String SUM_LOSS =
         "NMF_TRAINER_SUM_LOSS";
 
-    // The key denoting the number of training data elements (each (row, col) element) processed per unit time.
+    // The key denoting the number of training data instances processed per unit time.
     static final String DVT =
         "NMF_TRAINER_DVT";
-
-    // The key denoting the number of training data instances processed per unit time.
-    static final String RVT =
-        "NMF_TRAINER_RVT";
   }
 }


### PR DESCRIPTION
This PR cleans up the worker-side metrics in 3 algorithms (NMF, MLR, LDA), and make metrics consistent which used to be different across them. This work is for facilitating our analysis on log data.
