### PR TITLE
[CAY-880] Bug - DeviceMode enum has wrong value in NeuralNetwork proto file

### DIFF
--- a/dolphin/async/src/main/proto/neural_network.proto
+++ b/dolphin/async/src/main/proto/neural_network.proto
@@ -87,7 +87,7 @@ message NeuralNetworkConfiguration {
   optional uint32 random_seed = 5;
   enum DeviceMode {
     CPU = 0;
-    GPU = 0;
+    GPU = 1;
   }
   optional DeviceMode device_mode = 6 [default = CPU];
 }


### PR DESCRIPTION
Closes #880.

This PR fixes the DeviceMode enum value for GPU to be different from the CPU value.
