### PR TITLE
[MINOR] Fix a corner case in LDA when the updated value becomes negative 

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDAUpdater.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDAUpdater.java
@@ -49,6 +49,12 @@ final class LDAUpdater implements ParameterUpdater<Integer, int[], int[]> {
       final int index = deltaValue[i++];
       final int oldCount = oldValue[index];
       oldValue[index] += deltaValue[i++];
+
+      // Topic assignments should be non-negative, so the negative result is replaced to zero.
+      if (oldValue[index] < 0) {
+        oldValue[index] = 0;
+      }
+
       // should care about the case when the value is changed from non-zero to zero, vice versa
       if (oldCount == 0 && oldValue[index] != 0) {
         oldValue[numTopics]++;


### PR DESCRIPTION
In LDA, @gyeongin and I observed that topic counts can become negative, which in turn fails to compute valid log-likelihood.

This PR simply fixes the corner case by assigning zero instead of leaving negative value.
