### PR TITLE
[MINOR] Fix DNN doesn't work with yarn

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkREEF.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkREEF.java
@@ -105,7 +105,7 @@ public final class NeuralNetworkREEF {
     final JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
     final CommandLineFilter clf = new CommandLineFilter(cb);
 
-    clf.registerShortNameOfClass(OnLocal.class, true);
+    clf.registerShortNameOfClass(OnLocal.class, false);
     clf.registerShortNameOfClass(ConfigurationPath.class);
 
     clf.processCommandLine(args);


### PR DESCRIPTION
* The `onLocal` argument is kept instead of being filtered out.