### PR TITLE
[MINOR] Use consistent ThreadSafe annotations

### DIFF
--- a/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/BlockManager.java
+++ b/services/elastic-memory/src/main/java/edu/snu/cay/services/em/driver/impl/BlockManager.java
@@ -19,11 +19,11 @@ import edu.snu.cay.services.em.common.parameters.NumTotalBlocks;
 import edu.snu.cay.services.em.optimizer.api.EvaluatorParameters;
 import edu.snu.cay.services.em.optimizer.impl.DataInfoImpl;
 import edu.snu.cay.services.em.optimizer.impl.EvaluatorParametersImpl;
-import net.jcip.annotations.ThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.tang.annotations.Parameter;
 
+import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;


### PR DESCRIPTION
All the `ThreadSafe` annotations are `javax.annotation.concurrent.ThreadSafe`, except the one in `BlockManager`. This PR resolves this inconsistency.