### PR TITLE
[CAY-971] Enable multi-thread in NMF Trainer

### DIFF
--- a/dolphin/async/bin/run_mlr.sh
+++ b/dolphin/async/bin/run_mlr.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_mlr.sh -split 4 -num_servers 2 -num_partitions 4 -local true -input sample_mlr -max_num_eval_local 7 -max_iter 20 -mini_batch_size 50 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -lambda 0.005 -timeout 200000 -decay_period 5 -decay_rate 0.9 -dynamic true -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.plan.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_mlr.sh -split 4 -num_servers 2 -num_partitions 4 -local true -input sample_mlr -max_num_eval_local 7 -max_iter 20 -mini_batch_size 50 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -lambda 0.005 -timeout 200000 -decay_period 5 -decay_rate 0.9 -dynamic true -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.plan.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -server_log_period_ms 0 -server_metrics_window_ms 1000 -num_trainer_threads 1
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_nmf.sh
+++ b/dolphin/async/bin/run_nmf.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_nmf.sh -max_iter 500 -local true -split 4 -max_num_eval_local 5 -input sample_nmf -mini_batch_size 4 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -decay_period 5 -decay_rate 0.9 -dynamic true -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.plan.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000
+# ./run_nmf.sh -max_iter 500 -local true -split 4 -max_num_eval_local 5 -input sample_nmf -mini_batch_size 4 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -decay_period 5 -decay_rate 0.9 -dynamic true -optimizer edu.snu.cay.services.em.optimizer.impl.EmptyPlanOptimizer -plan_executor edu.snu.cay.dolphin.async.plan.AsyncDolphinPlanExecutor -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -worker_log_period_ms 0 -server_log_period_ms 0 -server_metrics_window_ms 1000 -num_trainer_threads 1
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFModel.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFModel.java
@@ -62,7 +62,7 @@ final class NMFModel implements Copyable<NMFModel> {
    */
   private Map<Integer, Vector> copyMap(final Map<Integer, Vector> toCopy) {
     final Map<Integer, Vector> copied = new HashMap<>(toCopy.size());
-    toCopy.forEach((integer, vectorEntries) -> copied.put(integer, vectorEntries.copy()));
+    toCopy.forEach((integer, vector) -> copied.put(integer, vector.copy()));
     return copied;
   }
 }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -346,8 +346,8 @@ final class NMFTrainer implements Trainer {
       // aggregate L matrix gradients
       lGradSum.addi(lGrad);
 
-      // save R matrix gradients
-      saveRMatrixGradient(colIdx, rGrad, model);
+      // accumulate R matrix's gradient
+      accumulateRMatrixGradient(colIdx, rGrad, model);
     }
 
     // update L matrix
@@ -436,12 +436,12 @@ final class NMFTrainer implements Trainer {
   }
 
   /**
-   * Saves a new gradient into the model.
+   * Accumulates a new gradient into the R Matrix's gradient.
    * @param colIdx index of the column that the gradient is associated with
-   * @param newGrad new gradient vector to save.
-   * @param model current model parameters of a row.
+   * @param newGrad new gradient vector to accumulate
+   * @param model current model parameters that contain R Matrix and its gradient
    */
-  private void saveRMatrixGradient(final int colIdx, final Vector newGrad, final NMFModel model) {
+  private void accumulateRMatrixGradient(final int colIdx, final Vector newGrad, final NMFModel model) {
     final Map<Integer, Vector> rMatrix = model.getRMatrix();
     final Map<Integer, Vector> gradients = model.getRGradient();
 


### PR DESCRIPTION
Closes #971.

This PR should be merged after #967.

Changes:
* Spawn multiple threads to parallelize computation
* Encapsulate the model in NMF to NMFModel
* Use ModelAccessor to access the model

Experimental settings:
* Optiplex-9020 cluster (4 physical cores, 32GB)
* 1 Server, 2 Workers
* Dataset - 10% sample of Netflix (48000 instances)
* Batch size - 5000

Results:
![image](https://cloud.githubusercontent.com/assets/1748276/21878101/2546a65e-d8d3-11e6-8585-865ffc887ecf.png)
![image](https://cloud.githubusercontent.com/assets/1748276/21878102/27e9939e-d8d3-11e6-83b1-1a30fc87cf7a.png)
We can see the time for computation decreases by about 30% (20.0s->13.9s), and the time for convergence decreases by around 15% (9.4s -> 8.0s).