### PR TITLE
[MINOR] Remove two trailing semicolons

### DIFF
--- a/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
+++ b/services/ps/src/main/java/edu/snu/cay/services/ps/driver/impl/EMRoutingTableManager.java
@@ -57,7 +57,7 @@ public final class EMRoutingTableManager {
   /**
    * A mapping between store id and endpoint id of server-side evaluators.
    */
-  private final BiMap<Integer, String> storeIdToEndpointId = HashBiMap.create();;
+  private final BiMap<Integer, String> storeIdToEndpointId = HashBiMap.create();
 
   /**
    * Server-side EMMaster instance.


### PR DESCRIPTION
In EMRoutingTableManager, we've had two trailing semicolons. Checkstyle does not complain, but it should be removed.