### PR TITLE
[CAY-990] Improve the performance of TrainingDataProvider's getNextTrainingData function

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -101,9 +101,10 @@ public final class TrainingDataProvider<K, V> {
         return Collections.emptyMap();
       }
 
-      final int actualBatchSize = Math.min(miniBatchSize, trainingDataKeys.size());
-      nextTrainingDataKeyList = new ArrayList<>(trainingDataKeys.subList(0, actualBatchSize));
-      trainingDataKeys = trainingDataKeys.subList(actualBatchSize, trainingDataKeys.size());
+      final int numRemainingKeys = trainingDataKeys.size();
+      final int nextBatchSize = Math.min(miniBatchSize, numRemainingKeys);
+      nextTrainingDataKeyList = new ArrayList<>(trainingDataKeys.subList(0, nextBatchSize));
+      trainingDataKeys = trainingDataKeys.subList(nextBatchSize, numRemainingKeys);
     }
 
     final Map<K, V> nextTrainingData = new HashMap<>();


### PR DESCRIPTION
This closes #990 

This PR improves the performance of a TrainingDataProvider's getNextTrainingData function.
Before the PR, since the time complexity of the `removeAll()`(which is in the `getNextTrainingData()`) is about O(n^2), the function's performance is very slow when the size of the dataset is very large(n is the size of the dataset).
Thus, this PR removed the `removeAll()` function and used subList function instead.
It is possible because nextTrainingDataKeyList is made up of the first mini-batch-sized subList of the trainingDataKeys.

The following is the result of the performance improvement(unit is a millisecond, with dataset size 144000) :
before the PR: getNextTrainingData() takes 40000 in average.
after the PR: getNextTrainingData() takes 100 in average.