### PR TITLE
[MINOR] Improve synchronization cost for accessing training data

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
@@ -98,6 +98,7 @@ final class SparseLDASampler {
             }
 
             drainedInstances.forEach(instance -> updateModel(instance, model));
+            drainedInstances.clear();
             count += numDrained;
           }
           latch.countDown();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -252,6 +252,7 @@ final class MLRTrainer implements Trainer {
               }
 
               drainedInstances.forEach(instance -> updateModel(instance, model));
+              drainedInstances.clear();
               count += numDrained;
             }
             latch.countDown();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -203,6 +203,7 @@ final class NMFTrainer implements Trainer {
               }
 
               drainedInstances.forEach(instance -> updateModel(instance, model));
+              drainedInstances.clear();
               count += numDrained;
             }
             latch.countDown();


### PR DESCRIPTION
Currently, Trainer's threads are accessing single instance from a concurrent queue each time. I observed that the performance gain by using more threads is lower than expected due to synchronization overhead.

This PR, as @wynot12 suggested, changes the threads to drain multiple items (numInstancesToProcess / numTrainerThreads) from the queue each time.