### PR TITLE
[CAY-995] Fix performance declining problem in getNextTrainingData()

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -102,10 +102,9 @@ public final class TrainingDataProvider<K, V> {
       }
 
       final int nextBatchSize = Math.min(miniBatchSize, trainingDataKeys.size());
-      nextTrainingDataKeyList = new ArrayList<>(trainingDataKeys.subList(0, nextBatchSize));
-      for (int i = 0; i < nextBatchSize; i++) {
-        trainingDataKeys.remove(0);
-      }
+      final List<K> keysToTrain = trainingDataKeys.subList(0, nextBatchSize);
+      nextTrainingDataKeyList = new ArrayList<>(keysToTrain);
+      keysToTrain.clear();
     }
 
     final Map<K, V> nextTrainingData = new HashMap<>();


### PR DESCRIPTION
This closes #995  

To solve the performance declining problem, occurred by garbage collector, instead of using subList function, it would be better to use remove function like before.
However, since removeAll function is slow, by removing the first entry of trainingDataKeys iteratively, the speed of the function is still fast and also the GC problem is solved.