### PR TITLE
[MINOR] Fix potential concurrency bug in TrainingDataProvider

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -24,7 +24,6 @@ import org.apache.reef.annotations.audience.TaskSide;
 import org.apache.reef.io.network.util.Pair;
 import org.apache.reef.tang.annotations.Parameter;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import java.util.*;


### PR DESCRIPTION
`Synchronized(Class)` does not guarantee thread-visibility of non-concurrent data structures (e.g., LinkedList) in its class fields.
We need to use concurrent data structures (e.g., CopyOnWriteArrayList) or use `SynchronizedCollection`.

This PR fixes it.