### PR TITLE
[ATC] Check abort flag for every batch in NMF/MLR/LDA

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
@@ -17,6 +17,8 @@ package edu.snu.cay.dolphin.async;
 
 import org.apache.reef.annotations.audience.TaskSide;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * A trainer of a {@code dolphin-async} application.
  *
@@ -49,8 +51,9 @@ public interface Trainer {
    * {@link edu.snu.cay.common.param.Parameters.Iterations}.
    *
    * @param iteration the index of current iteration
+   * @param abortFlag a flag indicating trainer to abort
    */
-  void run(int iteration);
+  void run(int iteration, AtomicBoolean abortFlag);
 
   /**
    * Post-run method executed after {@code run} but before task termination, exactly once.

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
@@ -27,6 +27,7 @@ import edu.snu.cay.services.em.exceptions.IdGenerationException;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -82,7 +83,7 @@ final class NeuralNetworkTrainer implements Trainer {
   }
 
   @Override
-  public void run(final int iteration) {
+  public void run(final int iteration, final AtomicBoolean abortFlag) {
     final Map<Long, NeuralNetworkData> workloadMap = memoryStore.getAll();
     final Collection<NeuralNetworkData> workload = workloadMap.values();
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
@@ -26,6 +26,7 @@ import edu.snu.cay.services.ps.worker.api.ParameterWorker;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -112,7 +113,7 @@ final class AddIntegerTrainer implements Trainer {
   }
 
   @Override
-  public void run(final int iteration) {
+  public void run(final int iteration, final AtomicBoolean abortFlag) {
     // sleep to simulate computation
     computeTracer.startTimer();
     try {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -29,6 +29,7 @@ import org.apache.reef.tang.annotations.Parameter;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -135,7 +136,7 @@ final class AddVectorTrainer implements Trainer {
   }
 
   @Override
-  public void run(final int iteration) {
+  public void run(final int iteration, final AtomicBoolean abortFlag) {
     final long epochStartTime = System.currentTimeMillis();
 
     // run mini-batches

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
@@ -28,6 +28,7 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -115,7 +116,7 @@ final class LassoTrainer implements Trainer {
    * 4) Push value to server.
    */
   @Override
-  public void run(final int iteration) {
+  public void run(final int iteration, final AtomicBoolean abortFlag) {
     final List<LassoData> totalInstancesProcessed = new LinkedList<>();
     Map<Long, LassoData> nextTrainingData = trainingDataProvider.getNextTrainingData();
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
@@ -31,6 +31,7 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -134,7 +135,7 @@ final class LDATrainer implements Trainer {
   }
 
   @Override
-  public void run(final int iteration) {
+  public void run(final int iteration, final AtomicBoolean abortFlag) {
     final long epochStartTime = System.currentTimeMillis();
 
     // Record the number of EM data blocks at the beginning of this iteration
@@ -147,6 +148,11 @@ final class LDATrainer implements Trainer {
 
     Map<Long, Document> nextTrainingData = trainingDataProvider.getNextTrainingData();
     while (!nextTrainingData.isEmpty()) {
+      if (abortFlag.get()) {
+        LOG.log(Level.INFO, "Abort a thread to completely close the task");
+        return;
+      }
+
       final Collection<Document> documents = nextTrainingData.values();
       final int numInstancesToProcess = documents.size();
 


### PR DESCRIPTION
Upon EM's DEL, workers stop after finish the current running epoch, but it takes too much time.
So this PR changes them to stop after the current running batch.

Note that this PR is toward a branch that we use temporary for ATC.