### PR TITLE
[MINOR] Bypass initialization for added workers

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
@@ -80,10 +80,10 @@ final class AsyncWorkerTask<K, V> implements Task {
           "Will skip initializing TrainingDataProvider and Trainer");
     } else {
       // Prepare the training data to be accessible via TrainingDataProvider.
-      trainingDataProvider.initialize();
+      trainingDataProvider.loadData();
 
       // TODO #681: Need to add numWorkerThreads concept after multi-thread trainer is enabled
-      trainer.initialize();
+      trainer.initGlobalSettings();
     }
 
     // synchronize all workers before starting the main iteration

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/Trainer.java
@@ -24,8 +24,9 @@ import java.util.Collection;
  *
  * Classes implementing this interface should consist of
  * a main {@code run} method that is executed once every iteration, as well as
- * a pre-run method {@code initialize} and post-run method {@code cleanup}, which are
- * executed before and after the main run loop, respectively.
+ * a pre-run method {@code initGlobalSettings} and post-run method {@code cleanup}, which are
+ * executed before and after the main run loop, respectively. Note that {@code initGlobalSettings} is optional, since
+ * we do not need to initialize global settings while the job is running already.
  *
  * Implementations should also have at least one constructor that is marked with the {@link javax.inject.Inject}
  * annotation, so that the framework can successfully instantiate the class via dependency injection.
@@ -44,9 +45,11 @@ import java.util.Collection;
 public interface Trainer<D> {
 
   /**
-   * Pre-run method that is executed after the constructor but before {@code run}, exactly once.
+   * Pre-run method that initializes the global settings (e.g., model parameters).
+   * This method is executed exactly once before {@code run}, if the job's state is
+   * in {@link SynchronizationManager.State#INIT}. Note that this method is skipped in other states.
    */
-  void initialize();
+  void initGlobalSettings();
 
   /**
    * Main method of this trainer, which is called every mini-batch.

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -62,9 +62,9 @@ public final class TrainingDataProvider<K, V> {
   }
 
   /**
-   * Prepares the training data to be accessible via MemoryStore.
+   * Loads the training data and make it accessible via MemoryStore.
    */
-  void initialize() {
+  void loadData() {
     final List<V> dataValues = dataParser.parse();
     final List<K> dataKeys;
     try {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/dnn/NeuralNetworkTrainer.java
@@ -69,7 +69,7 @@ final class NeuralNetworkTrainer implements Trainer<NeuralNetworkData> {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
     // put input data instances into the memory store
     final List<NeuralNetworkData> dataValues = dataParser.get();
     final List<Long> dataKeys;

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
@@ -102,7 +102,7 @@ final class AddIntegerTrainer implements Trainer {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
   }
 
   @Override

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -119,7 +119,7 @@ final class AddVectorTrainer implements Trainer {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
   }
 
   @Override

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
@@ -117,7 +117,7 @@ final class LassoTrainer implements Trainer<LassoData> {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
   }
 
   /**

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
@@ -115,7 +115,7 @@ final class LDATrainer implements Trainer<Document> {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
     // In LDA, topic counts should be initialized by pushing values before running.
     final TopicChanges topicChanges = new TopicChanges();
     final Map<Long, Document> data = memoryStore.getAll();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -191,7 +191,7 @@ final class MLRTrainer implements Trainer<MLRData> {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
   }
 
   @Override

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -148,7 +148,7 @@ final class NMFTrainer implements Trainer<NMFData> {
   }
 
   @Override
-  public void initialize() {
+  public void initGlobalSettings() {
   }
 
   @Override


### PR DESCRIPTION
`TrainingProvider.initiailize()` and `Trainer.initialize()` are used to take required actions that all workers should take before actual training. For example, `TrainingDataProvider.initialize()` prepare the data to be accessible via MemoryStore. 

For added workers, however, taking these actions can be problematic: for example, `LDATrainer.initialize()` has a logic to push the initial topics at the beginning. Without this PR, the added workers turn out to re-initialize the topics, losing the progress.