### PR TITLE
[MINOR] Add missing an app parameter in Lasso

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoREEF.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoREEF.java
@@ -39,9 +39,10 @@ public final class LassoREEF {
         .setWorkerSerializerClass(LassoDataSerializer.class)
         .addParameterClass(NumFeatures.class)
         .addParameterClass(StepSize.class)
+        .addParameterClass(Lambda.class)
+        .addParameterClass(ModelGaussian.class)
         .addParameterClass(DecayRate.class)
         .addParameterClass(DecayPeriod.class)
-        .addParameterClass(Lambda.class)
         .build());
   }
 }


### PR DESCRIPTION
Current LassoREEF does not bind `ModelGaussian` parameter. We should add it.