### PR TITLE
[MINOR] Separate out dolphin-async specific parameters from common parameters

### DIFF
--- a/common/src/main/java/edu/snu/cay/common/param/Parameters.java
+++ b/common/src/main/java/edu/snu/cay/common/param/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Seoul National University
+ * Copyright (C) 2017 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,31 +69,10 @@ public final class Parameters {
   public final class LocalRuntimeMaxNumEvaluators implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Maximum number of epochs to run before termination",
-                  short_name = "max_num_epochs")
-  public final class MaxNumEpochs implements Name<Integer> {
-  }
-
   @NamedParameter(doc = "The fraction of the container memory NOT to use for the Java Heap",
                   short_name = "heap_slack",
                   default_value = "0.0")
   public final class JVMHeapSlack implements Name<Double> {
-  }
-
-  @NamedParameter(doc = "Number of mini-batches",
-      short_name = "num_mini_batch",
-      default_value = "1")
-  public final class MiniBatches implements Name<Integer> {
-  }
-
-  @NamedParameter(doc = "Mini-batch size in number of training data instances",
-      short_name = "mini_batch_size")
-  public final class MiniBatchSize implements Name<Integer> {
-  }
-
-  @NamedParameter(doc = "Number of threads to run Trainer with",
-      short_name = "num_trainer_threads", default_value = "1")
-  public final class NumTrainerThreads implements Name<Integer> {
   }
 
   @NamedParameter(doc = "The minimum cost benefit (in a ratio) for which system optimization occurs. " +

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinDriver.java
@@ -311,7 +311,7 @@ public final class AsyncDolphinDriver {
                              @Parameter(Parameters.NumEvaluatorCores.class) final int numEvalCores,
                              @Parameter(NumServers.class) final int numServers,
                              final ConfigurationSerializer configurationSerializer,
-                             @Parameter(Parameters.MaxNumEpochs.class) final int maxNumEpochs,
+                             @Parameter(DolphinParameters.MaxNumEpochs.class) final int maxNumEpochs,
                              @Parameter(OptimizationIntervalMs.class) final long optimizationIntervalMs,
                              final MetricManager metricManager,
                              final HTraceParameters traceParameters,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncDolphinLauncher.java
@@ -169,12 +169,12 @@ public final class AsyncDolphinLauncher {
       final Configuration basicWorkerConf = Tang.Factory.getTang().newConfigurationBuilder()
           .bindImplementation(Trainer.class, asyncDolphinConfiguration.getTrainerClass())
           .bindImplementation(DataParser.class, asyncDolphinConfiguration.getParserClass())
-          .bindNamedParameter(MaxNumEpochs.class,
-              Integer.toString(basicParameterInjector.getNamedInstance(MaxNumEpochs.class)))
-          .bindNamedParameter(MiniBatchSize.class,
-              Integer.toString(basicParameterInjector.getNamedInstance(MiniBatchSize.class)))
-          .bindNamedParameter(NumTrainerThreads.class,
-              Integer.toString(basicParameterInjector.getNamedInstance(NumTrainerThreads.class)))
+          .bindNamedParameter(DolphinParameters.MaxNumEpochs.class,
+              Integer.toString(basicParameterInjector.getNamedInstance(DolphinParameters.MaxNumEpochs.class)))
+          .bindNamedParameter(DolphinParameters.MiniBatchSize.class,
+              Integer.toString(basicParameterInjector.getNamedInstance(DolphinParameters.MiniBatchSize.class)))
+          .bindNamedParameter(DolphinParameters.NumTrainerThreads.class,
+              Integer.toString(basicParameterInjector.getNamedInstance(DolphinParameters.NumTrainerThreads.class)))
           .build();
       final Configuration workerConf = Configurations.merge(basicWorkerConf,
           asyncDolphinConfiguration.getWorkerConfiguration());
@@ -257,11 +257,11 @@ public final class AsyncDolphinLauncher {
     basicParameterClassList.add(Splits.class);
     basicParameterClassList.add(Timeout.class);
     basicParameterClassList.add(LocalRuntimeMaxNumEvaluators.class);
-    basicParameterClassList.add(MaxNumEpochs.class);
+    basicParameterClassList.add(DolphinParameters.MaxNumEpochs.class);
     basicParameterClassList.add(JVMHeapSlack.class);
-    basicParameterClassList.add(MiniBatchSize.class);
+    basicParameterClassList.add(DolphinParameters.MiniBatchSize.class);
     basicParameterClassList.add(OptimizationBenefitThreshold.class);
-    basicParameterClassList.add(NumTrainerThreads.class);
+    basicParameterClassList.add(DolphinParameters.NumTrainerThreads.class);
 
     // add ps parameters
     basicParameterClassList.add(NumServers.class);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.cay.dolphin.async;
 
-import edu.snu.cay.common.param.Parameters.MaxNumEpochs;
 import edu.snu.cay.services.em.common.parameters.AddedEval;
 import edu.snu.cay.services.em.evaluator.api.MemoryStore;
 import edu.snu.cay.services.ps.worker.api.WorkerClock;
@@ -54,7 +53,7 @@ final class AsyncWorkerTask<K, V> implements Task {
 
   @Inject
   private AsyncWorkerTask(@Parameter(Identifier.class) final String taskId,
-                          @Parameter(MaxNumEpochs.class) final int maxNumEpochs,
+                          @Parameter(DolphinParameters.MaxNumEpochs.class) final int maxNumEpochs,
                           @Parameter(AddedEval.class) final boolean addedEval,
                           final WorkerSynchronizer synchronizer,
                           final TrainingDataProvider<K, V> trainingDataProvider,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.dolphin.async;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Dolphin-async specific parameters.
+ */
+public final class DolphinParameters {
+  @NamedParameter(doc = "Maximum number of epochs to run before termination",
+                  short_name = "max_num_epochs")
+  public final class MaxNumEpochs implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "Mini-batch size in number of training data instances",
+      short_name = "mini_batch_size")
+  public final class MiniBatchSize implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "Number of threads to run Trainer with",
+      short_name = "num_trainer_threads", default_value = "1")
+  public final class NumTrainerThreads implements Name<Integer> {
+  }
+}

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.cay.dolphin.async;
 
-import edu.snu.cay.common.param.Parameters;
 import edu.snu.cay.services.em.evaluator.api.BlockUpdateListener;
 import edu.snu.cay.services.em.evaluator.api.DataIdFactory;
 import edu.snu.cay.services.em.evaluator.api.MemoryStore;
@@ -32,7 +31,7 @@ import java.util.logging.Logger;
 
 /**
  * Provides the training data to process in mini-batches, taking subset of training data no more than
- * {@link Parameters.MiniBatchSize} instances.
+ * {@link DolphinParameters.MiniBatchSize} instances.
  * This class is designed to handle concurrent accesses to the training data,
  * and react to block migration by registering {@link BlockUpdateListener}.
  * @param <K> type of the key, which should be the same with the one in MemoryStore.
@@ -51,7 +50,7 @@ final class TrainingDataProvider<K, V> {
   private final DataParser<V> dataParser;
 
   @Inject
-  private TrainingDataProvider(@Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+  private TrainingDataProvider(@Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                                final MemoryStore<K> memoryStore,
                                final DataIdFactory<K> dataIdFactory,
                                final DataParser<V> dataParser) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addinteger/AddIntegerTrainer.java
@@ -16,7 +16,7 @@
 package edu.snu.cay.dolphin.async.examples.addinteger;
 
 import edu.snu.cay.common.metric.*;
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.EpochInfo;
 import edu.snu.cay.dolphin.async.MiniBatchInfo;
 import edu.snu.cay.dolphin.async.Trainer;
@@ -77,8 +77,8 @@ final class AddIntegerTrainer implements Trainer {
 
   @Inject
   private AddIntegerTrainer(final ParameterWorker<Integer, Integer, Integer> parameterWorker,
-                            @Parameter(Parameters.MaxNumEpochs.class) final int maxNumEpochs,
-                            @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+                            @Parameter(DolphinParameters.MaxNumEpochs.class) final int maxNumEpochs,
+                            @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                             @Parameter(ExampleParameters.DeltaValue.class) final int delta,
                             @Parameter(ExampleParameters.NumKeys.class) final int numberOfKeys,
                             @Parameter(ExampleParameters.NumWorkers.class) final int numberOfWorkers,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/examples/addvector/AddVectorTrainer.java
@@ -17,7 +17,7 @@ package edu.snu.cay.dolphin.async.examples.addvector;
 
 import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.metric.MetricsMsgSender;
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.EpochInfo;
 import edu.snu.cay.dolphin.async.MiniBatchInfo;
 import edu.snu.cay.dolphin.async.Trainer;
@@ -87,8 +87,8 @@ final class AddVectorTrainer implements Trainer {
 
   @Inject
   private AddVectorTrainer(final ParameterWorker<Integer, Integer, Vector> parameterWorker,
-                           @Parameter(Parameters.MaxNumEpochs.class) final int maxNumEpochs,
-                           @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+                           @Parameter(DolphinParameters.MaxNumEpochs.class) final int maxNumEpochs,
+                           @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                            @Parameter(ExampleParameters.DeltaValue.class) final int delta,
                            @Parameter(ExampleParameters.NumKeys.class) final int numberOfKeys,
                            @Parameter(ExampleParameters.NumWorkers.class) final int numberOfWorkers,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/gbt/GBTTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/gbt/GBTTrainer.java
@@ -16,7 +16,7 @@
 package edu.snu.cay.dolphin.async.mlapps.gbt;
 
 import edu.snu.cay.common.math.linalg.Vector;
-import edu.snu.cay.common.param.Parameters.MaxNumEpochs;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.EpochInfo;
 import edu.snu.cay.dolphin.async.MiniBatchInfo;
 import edu.snu.cay.dolphin.async.Trainer;
@@ -133,7 +133,7 @@ final class GBTTrainer implements Trainer<GBTData> {
                      @Parameter(Gamma.class) final double gamma,
                      @Parameter(TreeMaxDepth.class) final int treeMaxDepth,
                      @Parameter(LeafMinSize.class) final int leafMinSize,
-                     @Parameter(MaxNumEpochs.class) final int maxNumEpochs,
+                     @Parameter(DolphinParameters.MaxNumEpochs.class) final int maxNumEpochs,
                      @Parameter(NumKeys.class) final int numKeys,
                      final GBTMetadataParser metadataParser) {
     this.parameterWorker = parameterWorker;

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
@@ -20,7 +20,7 @@ import edu.snu.cay.common.math.linalg.MatrixFactory;
 import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.common.metric.MetricsMsgSender;
 import edu.snu.cay.common.metric.avro.Metrics;
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.EpochInfo;
 import edu.snu.cay.dolphin.async.MiniBatchInfo;
 import edu.snu.cay.dolphin.async.Trainer;
@@ -110,7 +110,7 @@ final class LassoTrainer implements Trainer<LassoData> {
                        @Parameter(DecayRate.class) final double decayRate,
                        @Parameter(DecayPeriod.class) final int decayPeriod,
                        @Parameter(NumFeaturesPerPartition.class) final int numFeaturesPerPartition,
-                       @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+                       @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                        final VectorFactory vectorFactory,
                        final MatrixFactory matrixFactory,
                        final MetricsMsgSender<WorkerMetrics> metricsMsgSender) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/LDATrainer.java
@@ -18,11 +18,7 @@ package edu.snu.cay.dolphin.async.mlapps.lda;
 import com.google.common.collect.Table;
 import edu.snu.cay.common.metric.MetricsMsgSender;
 import edu.snu.cay.common.metric.avro.Metrics;
-import edu.snu.cay.dolphin.async.EpochInfo;
-import edu.snu.cay.dolphin.async.MiniBatchInfo;
-import edu.snu.cay.dolphin.async.ModelAccessor;
-import edu.snu.cay.dolphin.async.Trainer;
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.*;
 import edu.snu.cay.dolphin.async.metric.Tracer;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.dolphin.async.mlapps.lda.LDAParameters.*;
@@ -86,8 +82,8 @@ final class LDATrainer implements Trainer<Document> {
                      final ModelAccessor<LDAModel> modelAccessor,
                      @Parameter(NumVocabs.class) final int numVocabs,
                      @Parameter(NumTopics.class) final int numTopics,
-                     @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
-                     @Parameter(Parameters.NumTrainerThreads.class) final int numTrainerThreads) {
+                     @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
+                     @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads) {
     this.sampler = sampler;
     this.statCalculator = statCalculator;
     this.memoryStore = memoryStore;

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.async.mlapps.lda;
 
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.ModelAccessor;
 import edu.snu.cay.dolphin.async.mlapps.lda.LDAParameters.*;
 import edu.snu.cay.utils.ThreadUtils;
@@ -62,7 +62,7 @@ final class SparseLDASampler {
                            @Parameter(Beta.class) final double beta,
                            @Parameter(NumTopics.class) final int numTopics,
                            @Parameter(NumVocabs.class) final int numVocabs,
-                           @Parameter(Parameters.NumTrainerThreads.class) final int numTrainerThreads,
+                           @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads,
                            final ModelAccessor<LDAModel> modelAccessor) {
     this.alpha = alpha;
     this.beta = beta;

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -19,11 +19,7 @@ import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.math.linalg.VectorFactory;
 import edu.snu.cay.common.metric.MetricsMsgSender;
 import edu.snu.cay.common.metric.avro.Metrics;
-import edu.snu.cay.common.param.Parameters;
-import edu.snu.cay.dolphin.async.EpochInfo;
-import edu.snu.cay.dolphin.async.MiniBatchInfo;
-import edu.snu.cay.dolphin.async.ModelAccessor;
-import edu.snu.cay.dolphin.async.Trainer;
+import edu.snu.cay.dolphin.async.*;
 import edu.snu.cay.dolphin.async.metric.Tracer;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.services.ps.worker.api.ParameterWorker;
@@ -138,8 +134,8 @@ final class MLRTrainer implements Trainer<MLRData> {
                      @Parameter(Lambda.class) final double lambda,
                      @Parameter(DecayRate.class) final double decayRate,
                      @Parameter(DecayPeriod.class) final int decayPeriod,
-                     @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
-                     @Parameter(Parameters.NumTrainerThreads.class) final int numTrainerThreads,
+                     @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
+                     @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads,
                      final ModelAccessor<MLRModel> modelAccessor,
                      final MetricsMsgSender<WorkerMetrics> metricsMsgSender,
                      final VectorFactory vectorFactory) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -18,11 +18,7 @@ package edu.snu.cay.dolphin.async.mlapps.nmf;
 import com.google.common.collect.Sets;
 import edu.snu.cay.common.metric.MetricsMsgSender;
 import edu.snu.cay.common.metric.avro.Metrics;
-import edu.snu.cay.common.param.Parameters;
-import edu.snu.cay.dolphin.async.EpochInfo;
-import edu.snu.cay.dolphin.async.MiniBatchInfo;
-import edu.snu.cay.dolphin.async.ModelAccessor;
-import edu.snu.cay.dolphin.async.Trainer;
+import edu.snu.cay.dolphin.async.*;
 import edu.snu.cay.dolphin.async.metric.Tracer;
 import edu.snu.cay.common.math.linalg.Vector;
 import edu.snu.cay.common.math.linalg.VectorEntry;
@@ -108,9 +104,9 @@ final class NMFTrainer implements Trainer<NMFData> {
                      @Parameter(Lambda.class) final double lambda,
                      @Parameter(DecayRate.class) final double decayRate,
                      @Parameter(DecayPeriod.class) final int decayPeriod,
-                     @Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+                     @Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                      @Parameter(PrintMatrices.class) final boolean printMatrices,
-                     @Parameter(Parameters.NumTrainerThreads.class) final int numTrainerThreads,
+                     @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads,
                      final ModelAccessor<NMFModel> modelAccessor,
                      final NMFModelGenerator modelGenerator,
                      final MemoryStore<Long> memoryStore,

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizer.java
@@ -16,6 +16,7 @@
 package edu.snu.cay.dolphin.async.optimizer;
 
 import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.dolphin.async.optimizer.parameters.Constants;
 import edu.snu.cay.dolphin.async.plan.EmptyPlan;
@@ -59,7 +60,7 @@ public final class AsyncDolphinOptimizer implements Optimizer {
   private final double optBenefitThreshold;
 
   @Inject
-  private AsyncDolphinOptimizer(@Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+  private AsyncDolphinOptimizer(@Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                                 @Parameter(ServerNumThreads.class) final int serverNumThreads,
                                 @Parameter(Parameters.OptimizationBenefitThreshold.class)
                                 final double optBenefitThreshold) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/HeterogeneousOptimizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/HeterogeneousOptimizer.java
@@ -16,6 +16,7 @@
 package edu.snu.cay.dolphin.async.optimizer;
 
 import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.dolphin.async.optimizer.parameters.Constants;
 import edu.snu.cay.dolphin.async.plan.EmptyPlan;
@@ -54,7 +55,7 @@ public final class HeterogeneousOptimizer implements Optimizer {
   private final Map<String, Double> hostnameToBandwidth;
 
   @Inject
-  private HeterogeneousOptimizer(@Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+  private HeterogeneousOptimizer(@Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                                  @Parameter(Parameters.NetworkBandwidth.class) final double defaultNetworkBandwidth,
                                  @Parameter(Parameters.OptimizationBenefitThreshold.class)
                                  final double optBenefitThreshold) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/HomogeneousOptimizer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/optimizer/HomogeneousOptimizer.java
@@ -16,6 +16,7 @@
 package edu.snu.cay.dolphin.async.optimizer;
 
 import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.dolphin.async.optimizer.parameters.Constants;
 import edu.snu.cay.dolphin.async.plan.EmptyPlan;
@@ -58,7 +59,7 @@ public final class HomogeneousOptimizer implements Optimizer {
   private final double optBenefitThreshold;
 
   @Inject
-  private HomogeneousOptimizer(@Parameter(Parameters.MiniBatchSize.class) final int miniBatchSize,
+  private HomogeneousOptimizer(@Parameter(DolphinParameters.MiniBatchSize.class) final int miniBatchSize,
                                @Parameter(Parameters.NetworkBandwidth.class) final double networkBandwidth,
                                @Parameter(Parameters.OptimizationBenefitThreshold.class)
                                final double optBenefitThreshold) {

--- a/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/TrainingDataProviderTest.java
+++ b/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/TrainingDataProviderTest.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.cay.dolphin.async;
 
-import edu.snu.cay.common.param.Parameters;
 import edu.snu.cay.services.em.common.parameters.KeyCodecName;
 import edu.snu.cay.services.em.common.parameters.MemoryStoreId;
 import edu.snu.cay.services.em.common.parameters.NumInitialEvals;
@@ -67,7 +66,7 @@ public class TrainingDataProviderTest {
         .bindNamedParameter(MemoryStoreId.class, Integer.toString(LOCAL_STORE_ID))
         .bindNamedParameter(NumInitialEvals.class, Integer.toString(NUM_MEMORY_STORES))
         .bindNamedParameter(NumTotalBlocks.class, Integer.toString(NUM_TOTAL_BLOCKS))
-        .bindNamedParameter(Parameters.MiniBatchSize.class, Integer.toString(MINI_BATCH_SIZE))
+        .bindNamedParameter(DolphinParameters.MiniBatchSize.class, Integer.toString(MINI_BATCH_SIZE))
         .build();
 
     final Injector injector = Tang.Factory.getTang().newInjector(conf);

--- a/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizerTest.java
+++ b/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/optimizer/AsyncDolphinOptimizerTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.cay.dolphin.async.optimizer;
 
-import edu.snu.cay.common.param.Parameters;
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.metric.avro.WorkerMetrics;
 import edu.snu.cay.dolphin.async.optimizer.parameters.Constants;
 import edu.snu.cay.services.em.optimizer.api.DataInfo;
@@ -71,7 +71,7 @@ public final class AsyncDolphinOptimizerTest {
     final Injector injector = Tang.Factory.getTang().newInjector(
         Tang.Factory.getTang().newConfigurationBuilder()
             .bindNamedParameter(ServerNumThreads.class, String.valueOf(NUM_SERVER_THREADS))
-            .bindNamedParameter(Parameters.MiniBatchSize.class, String.valueOf(miniBatchSize))
+            .bindNamedParameter(DolphinParameters.MiniBatchSize.class, String.valueOf(miniBatchSize))
         .build());
 
     // worker metrics


### PR DESCRIPTION
This PR adds `cay.dolphin.async.DolphinParameter`, which separates out dolphin-async specific parameters from  common parameters (`cay.common.param.Parameters`).