### PR TITLE
[CAY-1068] Implement WorkerStateManager

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerGlobalBarrier.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerGlobalBarrier.java
@@ -63,7 +63,7 @@ final class WorkerGlobalBarrier {
   /**
    * Worker waits on a global synchronization barrier.
    * When all threads have been observed at the barrier,
-   * It sends sends a synchronization message to the driver and blocks until
+   * it sends a synchronization message to the driver and waits until
    * a response message arrives from the driver.
    * After receiving the reply, this {@link WorkerGlobalBarrier} releases worker to progress.
    */
@@ -76,7 +76,7 @@ final class WorkerGlobalBarrier {
       break;
     case CLEANUP:
     default:
-      throw new RuntimeException("Invalid state");
+      throw new RuntimeException("Invalid state: await() cannot be called in the CLEANUP state");
     }
 
     sendMsgToDriver();

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerStateManager.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/WorkerStateManager.java
@@ -34,10 +34,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A driver-side component that coordinates synchronization messages between the driver and workerIds.
- * It is used to synchronize workerIds in two points: after initialization (STATE_INIT -> STATE_RUN)
+ * A driver-side component that coordinates synchronization between the driver and workers.
+ * It is used to synchronize workers in two points: after initialization (STATE_INIT -> STATE_RUN)
  * and before cleanup (STATE_RUN -> STATE_CLEANUP).
- * To achieve this, it maintains a global state that all workerIds should match with their own local states.
+ * To achieve this, it maintains a global state to be matched with their own local states.
  */
 @DriverSide
 @Unit
@@ -56,12 +56,12 @@ final class WorkerStateManager {
   private final StateMachine stateMachine;
 
   /**
-   * A set of workerIds to be synchronized.
+   * A set of ids of workers to be synchronized.
    */
   private final Set<String> workerIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   /**
-   * A set that maintains workerIds that have sent a sync msg for the barrier.
+   * A set maintaining worker ids of whom have sent a sync msg for the barrier.
    */
   @GuardedBy("this")
   private final Set<String> blockedWorkerIds = Collections.newSetFromMap(new ConcurrentHashMap<>());


### PR DESCRIPTION
Resolves #1068 

This PR implements `WorkerStateManager`, which is resembled from `SynchronizationManager`.

Different from `SynchronizationManager`, it does not consider the variability in the number of workers. The change in the number of workers by optimization will be handled in #1069. We may do it as the same way of `SynchronizationMananger` or a new better way, which fits for ET.