### PR TITLE
[CAY-1049] Remove MemoryStore from Trainers

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/AsyncWorkerTask.java
@@ -126,7 +126,7 @@ final class AsyncWorkerTask<K, V> implements Task {
 
       int miniBatchIdx = 0;
       while (true) {
-        final Collection<V> miniBatchData = trainingDataProvider.getNextTrainingData().values();
+        final Collection<V> miniBatchData = trainingDataProvider.getNextBatchData().values();
         if (miniBatchData.isEmpty()) {
           break; // Finish the epoch when there are no more data to process
         }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/EMTrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/EMTrainingDataProvider.java
@@ -90,7 +90,7 @@ final class EMTrainingDataProvider<K, V> implements TrainingDataProvider<K, V> {
   }
 
   @Override
-  public Map<K, V> getNextTrainingData() {
+  public Map<K, V> getNextBatchData() {
     final List<K> nextTrainingDataKeyList;
     synchronized (trainingDataKeys) {
       if (trainingDataKeys.isEmpty()) {
@@ -122,6 +122,11 @@ final class EMTrainingDataProvider<K, V> implements TrainingDataProvider<K, V> {
     }
 
     return nextTrainingData;
+  }
+
+  @Override
+  public Map<K, V> getEpochData() {
+    return memoryStore.getAll();
   }
 
   /**

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETTrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETTrainingDataProvider.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
  */
 @TaskSide
 @ThreadSafe
-public final class ETTrainingDataProvider<K, V> implements TrainingDataProvider {
+public final class ETTrainingDataProvider<K, V> implements TrainingDataProvider<K, V> {
   private static final Logger LOG = Logger.getLogger(ETTrainingDataProvider.class.getName());
   static final String TRAINING_DATA_TABLE_ID = "training_data_table";
 
@@ -71,7 +71,7 @@ public final class ETTrainingDataProvider<K, V> implements TrainingDataProvider 
    * @return a map of training data instances, which can be an empty Map if all data has been processed.
    */
   @Override
-  public Map<K, V> getNextTrainingData() {
+  public Map<K, V> getNextBatchData() {
     final List<K> nextTrainingDataKeyList;
     synchronized (trainingDataKeys) {
       if (trainingDataKeys.isEmpty()) {
@@ -102,5 +102,10 @@ public final class ETTrainingDataProvider<K, V> implements TrainingDataProvider 
     }
 
     return nextTrainingData;
+  }
+
+  @Override
+  public Map<K, V> getEpochData() {
+    return trainingDataTable.getLocalDataMap();
   }
 }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/TrainingDataProvider.java
@@ -30,7 +30,7 @@ public interface TrainingDataProvider<K, V> {
   void loadData();
 
   /**
-   * Prepares the data to process in the next epoch, accessible with calls to {@link #getNextTrainingData()}.
+   * Prepares the data to process in the next epoch, accessible with calls to {@link #getNextBatchData()}.
    */
   void prepareDataForEpoch();
 
@@ -38,5 +38,7 @@ public interface TrainingDataProvider<K, V> {
    * Provides the training data instances to compute in the next mini-batch.
    * @return a map of training data instances, which can be an empty Map if all data has been processed.
    */
-  Map<K, V> getNextTrainingData();
+  Map<K, V> getNextBatchData();
+
+  Map<K, V> getEpochData();
 }

--- a/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/EMTrainingDataProviderTest.java
+++ b/dolphin/async/src/test/java/edu/snu/cay/dolphin/async/EMTrainingDataProviderTest.java
@@ -110,11 +110,11 @@ public class EMTrainingDataProviderTest {
 
     trainingDataProvider.prepareDataForEpoch();
     testGetNextTrainingData(numTotalInstances);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
 
     trainingDataProvider.prepareDataForEpoch();
     testGetNextTrainingData(numTotalInstances);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
   }
 
   /**
@@ -130,11 +130,11 @@ public class EMTrainingDataProviderTest {
 
     trainingDataProvider.prepareDataForEpoch();
     testGetNextTrainingData(numTotalInstances);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
 
     trainingDataProvider.prepareDataForEpoch();
     testGetNextTrainingData(numTotalInstances);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
   }
 
   /**
@@ -150,7 +150,7 @@ public class EMTrainingDataProviderTest {
   }
 
   /**
-   * Test {@link TrainingDataProvider#getNextTrainingData()} gives right size of training data for each mini-batch
+   * Test {@link TrainingDataProvider#getNextBatchData()} gives right size of training data for each mini-batch
    * and provides training data for the exact number of mini-batches, total number of instances / mini-batch size
    * (or +1 depending on whether total number of instances is divisible by mini-batch size or not).
    * @param numTotalInstances the number of instances {@link TrainingDataProvider} currently has.
@@ -163,7 +163,7 @@ public class EMTrainingDataProviderTest {
 
     int miniBatchIdx = 0;
 
-    Map<Long, Integer> trainingData = trainingDataProvider.getNextTrainingData();
+    Map<Long, Integer> trainingData = trainingDataProvider.getNextBatchData();
     while (!trainingData.isEmpty()) {
       for (final Long key : trainingData.keySet()) {
         assertEquals(memoryStore.get(key).getSecond(), trainingData.get(key));
@@ -178,7 +178,7 @@ public class EMTrainingDataProviderTest {
         fail("The total number of mini-batches is larger than expectation");
       }
 
-      trainingData = trainingDataProvider.getNextTrainingData();
+      trainingData = trainingDataProvider.getNextBatchData();
       miniBatchIdx++;
     }
     assertEquals("The total number of mini-batches is different from expectation",
@@ -222,13 +222,13 @@ public class EMTrainingDataProviderTest {
     trainingDataProvider.prepareDataForEpoch(); // prepare training data for the epoch
     putBlockToMemoryStore(blockId, dataSet); // add a block to the MemoryStore
     testGetNextTrainingData(numInitialInstances + dataSet.size()); // verify the result of block addition
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
 
     // remove the added block from TrainingDataProvider at the beginning of epoch
     trainingDataProvider.prepareDataForEpoch(); // preparing training data for the epoch
     removeBlockFromMemoryStore(blockId); // remove a block from the MemoryStore
     testGetNextTrainingData(numInitialInstances); // verify the result of block removal
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
   }
 
   /**
@@ -246,12 +246,12 @@ public class EMTrainingDataProviderTest {
     trainingDataProvider.prepareDataForEpoch();
     final List <Pair<Integer, Map<Long, Integer>>> addedBlockList =
         testGetNextTrainingDataWithBlockAdditions(numTotalInstances);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
 
     // remove the added blocks from the MemoryStore during an epoch
     trainingDataProvider.prepareDataForEpoch();
     testGetNextTrainingDataWithBlockRemovals(addedBlockList);
-    assertTrue("Data should be exhausted", trainingDataProvider.getNextTrainingData().isEmpty());
+    assertTrue("Data should be exhausted", trainingDataProvider.getNextBatchData().isEmpty());
   }
 
   /**
@@ -273,7 +273,7 @@ public class EMTrainingDataProviderTest {
     int numRemovedInstances = 0;
     int numUsedInstances = 0;
 
-    Map<Long, Integer> trainingData = trainingDataProvider.getNextTrainingData();
+    Map<Long, Integer> trainingData = trainingDataProvider.getNextBatchData();
     while (!trainingData.isEmpty()) {
       // compare the given training data with the expected data set
       final Set<Long> keySet = trainingData.keySet();
@@ -307,7 +307,7 @@ public class EMTrainingDataProviderTest {
       }
 
       // load the next training data from the TrainingDataProvider
-      trainingData = trainingDataProvider.getNextTrainingData();
+      trainingData = trainingDataProvider.getNextBatchData();
       miniBatchIdx++;
     }
 
@@ -343,7 +343,7 @@ public class EMTrainingDataProviderTest {
     int numUsedInstances = 0;
     int addedBlockCount = 0;
 
-    Map<Long, Integer> trainingData = trainingDataProvider.getNextTrainingData();
+    Map<Long, Integer> trainingData = trainingDataProvider.getNextBatchData();
     while (!trainingData.isEmpty()) {
       // add a new block to the MemoryStore every third mini-batch including 0th
       if ((miniBatchIdx % 3 == 0) && (addedBlockCount < numBlocksToAdd)) {
@@ -364,7 +364,7 @@ public class EMTrainingDataProviderTest {
       // update the number of used instances by the size of training data
       sizeOfCurrentMiniBatch = trainingData.size();
       numUsedInstances += sizeOfCurrentMiniBatch;
-      trainingData = trainingDataProvider.getNextTrainingData();
+      trainingData = trainingDataProvider.getNextBatchData();
       miniBatchIdx++;
     }
 


### PR DESCRIPTION
Resolves #1049.

This PR removes Trainer's dependencies on EM's `MemoryStore`.
To achieve the goal, this PR adds `Map<K, V> getEpochData()`, which returns epoch data at once.