### PR TITLE
[CAY-1070] Redefine metrics for Dolphin-ET

### DIFF
--- a/dolphin/async/src/main/avro/dolphin_et.avsc
+++ b/dolphin/async/src/main/avro/dolphin_et.avsc
@@ -113,6 +113,7 @@
     {"name": "type", "type": {"type": "enum", "name": "MetricsType",
       "symbols": ["DolphinWorkerMetrics", "DolphinServerMetrics"]}},
     {"name": "workerMetrics", "type": ["null", "DolphinWorkerMetrics"], "default": null},
+    // serverMetrics is temporarily empty because the current cost model does not use server-specific metrics.
     {"name": "serverMetrics", "type": "null"},
     {"name": "etMetrics", "type": "ETMetrics"},
     {"name": "hostname", "type": "string", "default": ""}


### PR DESCRIPTION
Closes #1070 

This PR introduces a new Avro schema for metrics that will be used in Dolphin on ET.

Most fields inherit from Dolphin on PS's; I've re-organized the message hierarchy and removed default values for the fields that do not have to allow `null`.