### PR TITLE
[MINOR] Adopt a change in ET interface that introduces SubmittedTask

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinDriver.java
@@ -204,10 +204,10 @@ public final class ETDolphinDriver {
             modelTable.get().subscribe(workers);
             inputTable.get();
 
-            final List<Future<SubmittedTask>> taskResultFutureList = new ArrayList<>(workers.size());
-            workers.forEach(worker -> taskResultFutureList.add(worker.submitTask(getWorkerTaskConf())));
+            final List<Future<SubmittedTask>> taskFutureList = new ArrayList<>(workers.size());
+            workers.forEach(worker -> taskFutureList.add(worker.submitTask(getWorkerTaskConf())));
 
-            waitAndCheckTaskResult(taskResultFutureList);
+            waitAndCheckTaskResult(taskFutureList);
 
             workers.forEach(AllocatedExecutor::close);
             servers.forEach(AllocatedExecutor::close);


### PR DESCRIPTION
This PR adopts a change in ET's API that introduced `SubmittedTask` (cmssnu/elastic-tables#111).