### PR TITLE
[MINOR] Fix a corner case while identifying the metric source

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/ETDolphinMetricReceiver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/ETDolphinMetricReceiver.java
@@ -68,18 +68,18 @@ public final class ETDolphinMetricReceiver implements MetricReceiver {
       return;
     }
 
-    if (isServerMetrics(metricMsg)) {
-      processServerMetrics(srcId, metricMsg);
-    } else {
+    if (isWorkerMetrics(metricMsg)) {
       processWorkerMetrics(srcId, metricMsg);
+    } else {
+      processServerMetrics(srcId, metricMsg);
     }
   }
 
   /**
-   * Distinguishes the server metrics if the metrics consist of information of the model table.
+   * Distinguishes the metrics from workers if the metrics consist of information of the training data table.
    */
-  private boolean isServerMetrics(final MetricMsg metricMsg) {
-    return metricMsg.getTableToNumBlocks().containsKey(MODEL_TABLE_ID);
+  private boolean isWorkerMetrics(final MetricMsg metricMsg) {
+    return metricMsg.getTableToNumBlocks().containsKey(TRAINING_DATA_TABLE_ID);
   }
 
   /**


### PR DESCRIPTION
`ETDolphinMetricReceiver` identifies the source of metrics (i.e., whether the metrics are from servers/workers) by checking whether the information about the Model table is included in the message.
However, as Workers subscribe the model table, the metrics from Workers include the information about it - *I have 0 blocks of the Model table*. 

This PR fixes such corner case by checking whether the information about the `Training data table`, which always is included in Workers.