### PR TITLE
[MINOR] Specify mutability of tables

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinDriver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinDriver.java
@@ -161,6 +161,7 @@ public final class ETDolphinDriver {
         .setValueCodecClass(valueCodec.getClass())
         .setUpdateValueCodecClass(SerializableCodec.class)
         .setUpdateFunctionClass(VoidUpdateFunction.class)
+        .setIsMutableTable(false)
         .setIsOrderedTable(true)
         .setFilePath(inputPath)
         .setDataParserClass(dataParser.getClass())
@@ -181,6 +182,7 @@ public final class ETDolphinDriver {
         .setValueCodecClass(valueCodec.getClass())
         .setUpdateValueCodecClass(updateValueCodec.getClass())
         .setUpdateFunctionClass(updateFunction.getClass())
+        .setIsMutableTable(true)
         .setIsOrderedTable(false)
         .setUserParamConf(userParamConf)
         .build();


### PR DESCRIPTION
cmssnu/elastic-tables#163 has introduced feature that optimize migration for immutable tables. And it requires users to specify mutability of tables.

This PR updates `ETDolphinDriver` to specify table mutability for worker table (immutable) and server table (mutable).