### PR TITLE
[MINOR] Correct a minor error in accumulating metrics from batches

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
@@ -114,7 +114,7 @@ final class ETWorkerTask<K, V> implements Task {
             miniBatchData.size(), miniBatchElapsedTime);
 
         perOpTimeInEpoch.accumulate(miniBatchResult.getComputeTime(),
-            miniBatchResult.getAvgPullTime(), miniBatchResult.getAvgPushTime());
+            miniBatchResult.getTotalPullTime(), miniBatchResult.getTotalPushTime());
         epochData.addAll(miniBatchData);
         miniBatchIdx++;
 


### PR DESCRIPTION
This PR fixes an error in counting elapsed time for push/pull in an epoch.

The information is incorrect, but it does not change the optimization result because this field is not used in the cost model.