### PR TITLE
[MINOR] Make PlanExecutor choosable in ETDolphinLauncher

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
@@ -21,6 +21,7 @@ import edu.snu.cay.common.param.Parameters.*;
 import edu.snu.cay.dolphin.async.metric.ETDolphinMetricReceiver;
 import edu.snu.cay.dolphin.async.metric.parameters.ServerMetricFlushPeriodMs;
 import edu.snu.cay.dolphin.async.optimizer.parameters.*;
+import edu.snu.cay.dolphin.async.plan.ETPlanExecutorClass;
 import edu.snu.cay.services.em.optimizer.api.Optimizer;
 import edu.snu.cay.services.em.optimizer.conf.OptimizerClass;
 import edu.snu.cay.services.et.configuration.ETDriverConfiguration;
@@ -31,7 +32,6 @@ import edu.snu.cay.services.et.configuration.parameters.ValueCodec;
 import edu.snu.cay.services.et.evaluator.api.UpdateFunction;
 import edu.snu.cay.services.et.evaluator.api.DataParser;
 import edu.snu.cay.services.et.plan.api.PlanExecutor;
-import edu.snu.cay.services.et.plan.impl.LoggingPlanExecutor;
 import org.apache.commons.cli.ParseException;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.client.DriverConfiguration;
@@ -208,6 +208,7 @@ public final class ETDolphinLauncher {
     clientParamList.forEach(cl::registerShortNameOfClass);
     driverParamList.forEach(cl::registerShortNameOfClass);
     cl.registerShortNameOfClass(OptimizerClass.class); // handle it separately to bind a corresponding implementation
+    cl.registerShortNameOfClass(ETPlanExecutorClass.class); // handle it separately similar to OptimizerClass
     serverParamList.forEach(cl::registerShortNameOfClass);
     workerParamList.forEach(cl::registerShortNameOfClass);
     cl.registerShortNameOfClass(InputDir.class); // handle inputPath separately to process it through processInputDir()
@@ -230,9 +231,12 @@ public final class ETDolphinLauncher {
     final Class<? extends Optimizer> optimizerClass =
         (Class<? extends Optimizer>) Class.forName(commandlineParamInjector.getNamedInstance(OptimizerClass.class));
 
+    final Class<? extends PlanExecutor> planExecutorClass = (Class<? extends PlanExecutor>)
+        Class.forName(commandlineParamInjector.getNamedInstance(ETPlanExecutorClass.class));
+
     optimizationConf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindImplementation(Optimizer.class, optimizerClass)
-        .bindImplementation(PlanExecutor.class, LoggingPlanExecutor.class)
+        .bindImplementation(PlanExecutor.class, planExecutorClass)
         .bindNamedParameter(NumInitialResources.class, Integer.toString(numInitialResources))
         .build();
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/plan/ETPlanExecutorClass.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/plan/ETPlanExecutorClass.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.cay.dolphin.async.plan;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Implementation of ET's PlanExecutor",
+                short_name = "et_plan_executor",
+                default_value = "edu.snu.cay.services.et.plan.impl.PlanExecutorImpl")
+public final class ETPlanExecutorClass implements Name<String> {
+}


### PR DESCRIPTION
This PR makes PlanExecutor choosable in ETDolphinLauncher, by introducing a named parameter `ETPlanExecutorClass`. By default, the `PlanExecutorImpl` is used.

I’ve confirmed that the plan executor is set via the named parameter by adding `-et_plan_executor edu.snu.cay.services.et.plan.impl.LoggingPlanExecutor` at the end of `run_mlr_et.sh` command: 
* Command
```
./run_mlr_et.sh -num_workers 1 -number_servers 5 -local true -input sample_mlr -max_num_eval_local 6 -test_data_path file://$(PWD)/sample_mlr_test -max_num_epochs 20 -mini_batch_size 50 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -lambda 0.005 -timeout 200000 -decay_period 5 -decay_rate 0.9 -num_trainer_threads 1 -optimizer edu.snu.cay.dolphin.async.optimizer.HeterogeneousOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -et_plan_executor edu.snu.cay.services.et.plan.impl.LoggingPlanExecutor
```
* Result
```
➜  bin git:(minor-make-plan-executor-choosable) grep LoggingPlan REEF_LOCAL_RUNTIME/MLRET-1494030511754/driver/driver.stderr
2017-05-06 09:28:48,196 INFO cay.services.et.plan.impl.LoggingPlanExecutor.execute pool-2-thread-1 | Num total ops: 32
2017-05-06 09:28:48,197 INFO cay.services.et.plan.impl.LoggingPlanExecutor.execute pool-2-thread-1 | Execute 8 ops: [AllocateOp{virtualId=NewWorker-2, executorConf=edu.snu.cay.services.et.configuration.ExecutorConfiguration@4643538a}, AllocateOp{virtualId=NewWorker-1, executorConf=edu.snu.cay.services.et.configuration.ExecutorConfiguration@4643538a}, AllocateOp{virtualId=NewWorker-3, executorConf=edu.snu.cay.services.et.configuration.ExecutorConfiguration@4643538a}, MoveOp{srcExecutorId='Node-6-1494030513388', dstExecutorId='Node-2-1494030513165', tableId='model_table', numBlocks=205}, MoveOp{srcExecutorId='Node-3-1494030513355', dstExecutorId='Node-2-1494030513165', tableId='model_table', numBlocks=205}, MoveOp{srcExecutorId='Node-1-1494030513231', dstExecutorId='Node-2-1494030513165', tableId='model_table', numBlocks=205}, MoveOp{srcExecutorId='Node-4-1494030513312', dstExecutorId='Node-2-1494030513165', tableId='model_table', numBlocks=204}, AllocateOp{virtualId=NewWorker-0, executorConf=edu.snu.cay.services.et.configuration.ExecutorConfiguration@4643538a}]
2017-05-06 09:28:48,198 INFO cay.services.et.plan.impl.LoggingPlanExecutor.execute pool-2-thread-1 | Execute 12 ops: [UnassociateOp{executorId='Node-4-1494030513312', tableId='model_table'}, AssociateOp{executorId='NewWorker-2', tableId='training_data_table'}, UnassociateOp{executorId='Node-6-1494030513388', tableId='model_table'}, SubscribeOp{executorId='NewWorker-2', tableId='model_table'}, UnassociateOp{executorId='Node-1-1494030513231', tableId='model_table'}, AssociateOp{executorId='NewWorker-1', tableId='training_data_table'}, UnassociateOp{executorId='Node-3-1494030513355', tableId='model_table'}, SubscribeOp{executorId='NewWorker-1', tableId='model_table'}, AssociateOp{executorId='NewWorker-3', tableId='training_data_table'}, SubscribeOp{executorId='NewWorker-3', tableId='model_table'}, AssociateOp{executorId='NewWorker-0', tableId='training_data_table'}, SubscribeOp{executorId='NewWorker-0', tableId='model_table'}]
2017-05-06 09:28:48,199 INFO cay.services.et.plan.impl.LoggingPlanExecutor.execute pool-2-thread-1 | Execute 8 ops: [DeallocateOp{executorId='Node-4-1494030513312'}, DeallocateOp{executorId='Node-6-1494030513388'}, DeallocateOp{executorId='Node-1-1494030513231'}, DeallocateOp{executorId='Node-3-1494030513355'}, MoveOp{srcExecutorId='Node-5-1494030517049', dstExecutorId='NewWorker-0', tableId='training_data_table', numBlocks=205}, MoveOp{srcExecutorId='Node-5-1494030517049', dstExecutorId='NewWorker-1', tableId='training_data_table', numBlocks=205}, MoveOp{srcExecutorId='Node-5-1494030517049', dstExecutorId='NewWorker-2', tableId='training_data_table', numBlocks=205}, MoveOp{srcExecutorId='Node-5-1494030517049', dstExecutorId='NewWorker-3', tableId='training_data_table', numBlocks=204}]
2017-05-06 09:28:48,199 INFO cay.services.et.plan.impl.LoggingPlanExecutor.execute pool-2-thread-1 | Execute 4 ops: [StartOp{executorId='NewWorker-2', taskConf=org.apache.reef.tang.implementation.java.JavaConfigurationBuilderImpl$JavaConfigurationImpl@55c26523}, StartOp{executorId='NewWorker-1', taskConf=org.apache.reef.tang.implementation.java.JavaConfigurationBuilderImpl$JavaConfigurationImpl@3c9bf1d5}, StartOp{executorId='NewWorker-3', taskConf=org.apache.reef.tang.implementation.java.JavaConfigurationBuilderImpl$JavaConfigurationImpl@c4eba2a6}, StartOp{executorId='NewWorker-0', taskConf=org.apache.reef.tang.implementation.java.JavaConfigurationBuilderImpl$JavaConfigurationImpl@8d0a7e1a}]
```