### PR TITLE
[MINOR] Write log messages of received metrics at the Driver

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
@@ -106,6 +106,8 @@ final class ETWorkerTask<K, V> implements Task {
           break; // Finish the epoch when there are no more data to process
         }
 
+        LOG.log(Level.INFO, "Starting batch {0} in epoch {1}", new Object[] {miniBatchIdx, epochIdx});
+
         final long miniBatchStartTime = System.currentTimeMillis();
         final MiniBatchResult miniBatchResult = trainer.runMiniBatch(miniBatchData);
         final double miniBatchElapsedTime = (System.currentTimeMillis() - miniBatchStartTime) / 1000.0D;

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/ETDolphinMetricReceiver.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/metric/ETDolphinMetricReceiver.java
@@ -99,7 +99,7 @@ public final class ETDolphinMetricReceiver implements MetricReceiver {
         throw new RuntimeException("Unknown message type");
       }
 
-      LOG.log(Level.INFO, "Received a worker metric from {0}: {1}", new Object[] {workerMetrics, srcId});
+      LOG.log(Level.INFO, "Received a worker metric from {0}: {1}", new Object[] {srcId, workerMetrics});
     }
   }
 


### PR DESCRIPTION
When Servers/Workers write log messages when they send metrics to the Driver. However, since there could exist a clock skew, we cannot make sure when the log messages was actually written. Though we can reduce the difference by syncing machines’ clocks,  an easier and simpler way to avoid the problem would be printing logs at the driver when the metrics arrive.

This PR moves the place of writing logs to the Driver.