### PR TITLE
[MINOR] Run onEpochFinshed method on background thread

### DIFF
--- a/dolphin/async/src/main/avro/async.avsc
+++ b/dolphin/async/src/main/avro/async.avsc
@@ -140,9 +140,6 @@
     // total elapsed time for this epoch (seconds)
     {"name": "totalTime", "type": ["null", "double"], "default": null},
 
-    // elapsed time for summarizing epoch (seconds)
-    {"name": "epochSummaryTime", "type": ["null", "double"], "default": null},
-
     // total computation time for this epoch (seconds), only used for mini-batch metrics
     // required for optimization cost model
     {"name": "totalCompTime", "type": ["null", "double"], "default": null},

--- a/dolphin/async/src/main/avro/dolphin_et.avsc
+++ b/dolphin/async/src/main/avro/dolphin_et.avsc
@@ -88,7 +88,7 @@
     // total elapsed time for this epoch
     {"name": "epochTimeSec", "type": "double"},
 
-    // elapsed time for summarizing epoch (seconds)
+    // elapsed time for summarizing an epoch (seconds)
     {"name": "epochSummaryTimeSec", "type": ["null", "double"], "default": null},
 
     // total computation time for this epoch


### PR DESCRIPTION
Currently, `onEpochFinished()` method works on the same thread with `WorkerTask`.
However, they do not need to be in the same thread. Instead, making a new separate thread for `onEpochFinished()` method and running this thread on the background might be more efficient. This PR applies this point.

The following list is a description about changes in this PR :
1) Add `epochSummaryTime` metric for `EpochMetrics`. This metric is necessary to calculate actual finish time for each epoch.

2) Uses `singleThreadExecutor` because single thread is sufficient to run this method.

3) This `singleThreadExecutor` must wait for the last thread to be finished before `trainer.cleanup()`(by using `awaitTermiation()` method). Otherwise, some of the last epoch metrics will be lost. Here, I set `EPOCH_METRIC_SENDING_TIMEOUT` with 100000 milliseconds, which is thought to be sufficient time for any `onEpochFinished()` method.

4) Remove time stamp in `DriverSideMetricsMsgHandlerForWorker` which is unnecessary.