### PR TITLE
[MINOR] Run onEpochFinished method on the same thread with ETWorkerTask

### DIFF
--- a/dolphin/async/src/main/avro/dolphin_et.avsc
+++ b/dolphin/async/src/main/avro/dolphin_et.avsc
@@ -88,9 +88,6 @@
     // total elapsed time for this epoch
     {"name": "epochTimeSec", "type": "double"},
 
-    // elapsed time for summarizing an epoch (seconds)
-    {"name": "epochSummaryTimeSec", "type": ["null", "double"], "default": null},
-
     // total computation time for this epoch
     // required for optimization cost model
     {"name": "epochCompTimeSec", "type": "double"},

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETWorkerTask.java
@@ -24,9 +24,6 @@ import org.apache.reef.task.Task;
 
 import javax.inject.Inject;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,7 +33,6 @@ import java.util.logging.Logger;
  */
 final class ETWorkerTask<K, V> implements Task {
   private static final Logger LOG = Logger.getLogger(ETWorkerTask.class.getName());
-  private static final long EPOCH_METRIC_SENDING_TIMEOUT_MS = 100000;
   static final String TASK_ID_PREFIX = "ETWorkerTask";
 
   private final String taskId;
@@ -50,11 +46,6 @@ final class ETWorkerTask<K, V> implements Task {
   private final TestDataProvider<V> testDataProvider;
   private final Trainer<V> trainer;
   private final MetricCollector metricCollector;
-
-  /**
-   * An executor for running a thread in order to summarize an epoch (e.g., computing loss).
-   */
-  private final ExecutorService executor;
 
   /**
    * A boolean flag that becomes true when {@link #close()} is called,
@@ -83,7 +74,6 @@ final class ETWorkerTask<K, V> implements Task {
     this.testDataProvider = testDataProvider;
     this.trainer = trainer;
     this.metricCollector = metricCollector;
-    this.executor = Executors.newSingleThreadExecutor();
   }
 
   @Override
@@ -137,19 +127,9 @@ final class ETWorkerTask<K, V> implements Task {
       }
 
       final double epochElapsedTimeSec = (System.currentTimeMillis() - epochStartTime) / 1000.0D;
-      final int numMiniBatchForEpoch = miniBatchIdx;
-      final int thisEpochIdx = epochIdx;
-      executor.submit(() -> {
-        final long epochSummaryStartTimeMs = System.currentTimeMillis();
-        final EpochResult epochResult = trainer.onEpochFinished(epochData, testData, thisEpochIdx);
-        final double epochSummaryTimeSec = (System.currentTimeMillis() - epochSummaryStartTimeMs) / 1000.0D;
-
-        sendEpochMetrics(epochResult, thisEpochIdx, numMiniBatchForEpoch,
-            epochData.size(), epochElapsedTimeSec, epochSummaryTimeSec, perOpTimeInEpoch);
-      });
+      final EpochResult epochResult = trainer.onEpochFinished(epochData, testData, epochIdx);
+      sendEpochMetrics(epochResult, epochIdx, miniBatchIdx, epochData.size(), epochElapsedTimeSec, perOpTimeInEpoch);
     }
-    executor.shutdown();
-    executor.awaitTermination(EPOCH_METRIC_SENDING_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
     // Synchronize all workers before cleanup for workers
     // to finish with the globally equivalent view of trained model
@@ -214,7 +194,6 @@ final class ETWorkerTask<K, V> implements Task {
                                 final int epochIdx, final int miniBatchIdx,
                                 final int processedDataItemCount,
                                 final double epochElapsedTime,
-                                final double epochSummaryTime,
                                 final PerOpTimeInEpoch perOpTimeInEpoch) {
     // Build App-specific metrics (e.g., Loss, log-likelihood)
     final Metrics appMetrics = Metrics.newBuilder()
@@ -229,7 +208,6 @@ final class ETWorkerTask<K, V> implements Task {
         .setEpochPullTimeSec(perOpTimeInEpoch.getTotalPullTime())
         .setEpochPushTimeSec(perOpTimeInEpoch.getTotalPushTime())
         .setEpochTimeSec(epochElapsedTime)
-        .setEpochSummaryTimeSec(epochSummaryTime)
         .setNumBatchesForEpoch(miniBatchIdx)
         .setNumEpochDataInstances(processedDataItemCount)
         .build();


### PR DESCRIPTION
In PR #1147, `onEpochFinished` method was changed to be run on the new separate thread. However, it turns out that this change affects to metric collecting procedure. When `pull` operation is called in `onEpochFinished` method, `pullTracer` collects pull time metric, which should not be traced. Thus, this PR reverts the change, which was made in PR #1147.