### PR TITLE
[MINOR] Remove log entries in NMFTraine, which were added for debugging purpose

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -124,7 +124,6 @@ final class NMFTrainer implements Trainer<NMFData> {
     
     // pull data when mini-batch is started
     final List<Integer> keys = getKeys(instances);
-    LOG.log(Level.INFO, "Total number of keys = {0}", keys.size());
     final NMFModel model = pullModels(keys);
 
     // collect gradients computed in each thread
@@ -133,7 +132,6 @@ final class NMFTrainer implements Trainer<NMFData> {
       // Threads drain multiple instances from shared queue, as many as nInstances / (nThreads)^2.
       // This way we can mitigate the slowdown from straggler threads.
       final int drainSize = Math.max(instances.size() / numTrainerThreads / numTrainerThreads, 1);
-      LOG.log(Level.INFO, "Drained {0} items", drainSize);
 
       for (int threadIdx = 0; threadIdx < numTrainerThreads; threadIdx++) {
         final Future<Map<Integer, Vector>> future = executor.submit(() -> {
@@ -280,7 +278,6 @@ final class NMFTrainer implements Trainer<NMFData> {
 
     // update L matrix
     modelGenerator.getValidVector(lVec.axpy(-stepSize, lGradSum));
-    LOG.log(Level.INFO, "getValidVector");
   }
 
   /**


### PR DESCRIPTION
This PR removes the log entries that are quite unimportant, which were added for debugging purpose when we changed the data type from double to float.