### PR TITLE
[MINOR] Adopt ET-side changes in bulk-loading of input

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinMaster.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinMaster.java
@@ -293,7 +293,7 @@ public final class DolphinMaster {
           final Future<AllocatedTable> inputTable = etMaster.createTable(workerTableConf, workers);
 
           modelTable.get().subscribe(workers);
-          inputTable.get().load(workers, inputPath);
+          inputTable.get().load(workers, inputPath).get();
 
           final List<TaskResult> taskResults = taskRunner.run(workers, servers);
           checkTaskResults(taskResults);


### PR DESCRIPTION
This PR changes Dolphin to use recently changed Table data bulk-loading API (cmssnu/elastic-tables#175, cmssnu/elastic-tables#190)

This PR is exactly included in #1170, so I've made a separate PR.