### PR TITLE
[MINOR] Fix LDA's worker-side model inconsistency by migration

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/Document.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/Document.java
@@ -105,7 +105,7 @@ final class Document {
     final int oldTopic = assignments[index];
     topicCounts.compute(oldTopic, (key, oldValue) -> {
       if (oldValue == null || oldValue == 0) {
-        throw new RuntimeException(String.format("The TopicCounts for %d-th word is %d", index, oldValue));
+        return 0; // it happens due to inconsistency by migration of worker-side model
       } else {
         return oldValue - 1;
       }


### PR DESCRIPTION
This PR fixes the LDA's worker-side model inconsistency by migration.

LDA is fatal to model inconsistency (since it's not GD differently from other example apps), and we do not support consistency in worker-side model.

So this PR uses an ad-hoc way to restore the broken model and we confirmed that algorithm works well with this way.