### PR TITLE
[MINOR] Separate DecayPeriod from app specific to dolphin specific parameter

### DIFF
--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
@@ -156,7 +156,14 @@ public final class DolphinParameters {
                   default_value = "2")
   public final class NumWorkerSenderThreads implements Name<Integer> {
   }
-  
+
+  @NamedParameter(doc = "number of epochs to wait until learning rate decreases (periodic). this value must be " +
+                  "a positive value.",
+                  short_name = "decay_period",
+                  default_value = "5")
+  public static final class DecayPeriod implements Name<Integer> {
+  }
+
   @NamedParameter(doc = "The path of test data",
                   short_name = "test_data_path",
                   default_value = TestDataPath.NONE)

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
@@ -210,7 +210,7 @@ public final class ETDolphinLauncher {
     final List<Class<? extends Name<?>>> serverParamList = Collections.emptyList();
 
     final List<Class<? extends Name<?>>> workerParamList = Arrays.asList(
-        NumTrainerThreads.class, MaxNumEpochs.class, NumTotalMiniBatches.class, TestDataPath.class);
+        NumTrainerThreads.class, MaxNumEpochs.class, NumTotalMiniBatches.class, DecayPeriod.class, TestDataPath.class);
 
     final CommandLine cl = new CommandLine();
     clientParamList.forEach(cl::registerShortNameOfClass);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoET.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoET.java
@@ -17,7 +17,6 @@ package edu.snu.cay.dolphin.async.mlapps.lasso;
 
 import edu.snu.cay.dolphin.async.ETDolphinConfiguration;
 import edu.snu.cay.dolphin.async.ETDolphinLauncher;
-import edu.snu.cay.dolphin.async.mlapps.lda.*;
 import edu.snu.cay.dolphin.async.mlapps.serialization.DenseVectorCodec;
 import org.apache.reef.io.serialization.SerializableCodec;
 
@@ -49,7 +48,6 @@ public final class LassoET {
         .addParameterClass(Lambda.class)
         .addParameterClass(ModelGaussian.class)
         .addParameterClass(DecayRate.class)
-        .addParameterClass(DecayPeriod.class)
         .addParameterClass(NumFeaturesPerPartition.class)
         .build());
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoParameters.java
@@ -48,13 +48,6 @@ final class LassoParameters {
   static final class DecayRate implements Name<Double> {
   }
 
-  @NamedParameter(doc = "number of epochs to wait until learning rate decreases (periodic). this value must be " +
-          "a positive value.",
-          short_name = "decay_period",
-          default_value = "5")
-  static final class DecayPeriod implements Name<Integer> {
-  }
-  
   @NamedParameter(doc = "number of features for each model partition", short_name = "features_per_partition")
   static final class NumFeaturesPerPartition implements Name<Integer> {
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lasso/LassoTrainer.java
@@ -87,7 +87,7 @@ final class LassoTrainer implements Trainer<LassoData> {
                        @Parameter(NumFeatures.class) final int numFeatures,
                        @Parameter(StepSize.class) final float stepSize,
                        @Parameter(DecayRate.class) final double decayRate,
-                       @Parameter(DecayPeriod.class) final int decayPeriod,
+                       @Parameter(DolphinParameters.DecayPeriod.class) final int decayPeriod,
                        @Parameter(NumFeaturesPerPartition.class) final int numFeaturesPerPartition,
                        final VectorFactory vectorFactory,
                        final MatrixFactory matrixFactory) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRET.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRET.java
@@ -49,7 +49,6 @@ public final class MLRET {
         .addParameterClass(Lambda.class)
         .addParameterClass(NumFeaturesPerPartition.class)
         .addParameterClass(ModelGaussian.class)
-        .addParameterClass(DecayPeriod.class)
         .addParameterClass(DecayRate.class)
         .build());
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRParameters.java
@@ -57,13 +57,6 @@ final class MLRParameters {
   static final class DecayRate implements Name<Float> {
   }
 
-  @NamedParameter(doc = "number of epochs to wait until learning rate decreases (periodic). this value must be " +
-      "a positive value.",
-      short_name = "decay_period",
-      default_value = "5")
-  static final class DecayPeriod implements Name<Integer> {
-  }
-
   static final class MetricKeys {
 
     // The key denoting the sum of loss computed from the training data instances.

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -115,7 +115,7 @@ final class MLRTrainer implements Trainer<MLRData> {
                      @Parameter(InitialStepSize.class) final float initStepSize,
                      @Parameter(Lambda.class) final float lambda,
                      @Parameter(DecayRate.class) final float decayRate,
-                     @Parameter(DecayPeriod.class) final int decayPeriod,
+                     @Parameter(DolphinParameters.DecayPeriod.class) final int decayPeriod,
                      @Parameter(DolphinParameters.NumTotalMiniBatches.class) final int numTotalMiniBatches,
                      @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads,
                      final VectorFactory vectorFactory) {

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFET.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFET.java
@@ -47,7 +47,6 @@ public final class NMFET {
         .addParameterClass(StepSize.class)
         .addParameterClass(Lambda.class)
         .addParameterClass(PrintMatrices.class)
-        .addParameterClass(DecayPeriod.class)
         .addParameterClass(DecayRate.class)
         .build());
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFJobServer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFJobServer.java
@@ -47,7 +47,6 @@ public final class NMFJobServer {
         .addParameterClass(StepSize.class)
         .addParameterClass(Lambda.class)
         .addParameterClass(PrintMatrices.class)
-        .addParameterClass(DecayPeriod.class)
         .addParameterClass(DecayRate.class)
         .build());
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFParameters.java
@@ -42,13 +42,6 @@ final class NMFParameters {
   static final class DecayRate implements Name<Float> {
   }
 
-  @NamedParameter(doc = "number of epochs to wait until learning rate decreases (periodic). this value must be " +
-      "a positive value.",
-      short_name = "decay_period",
-      default_value = "5")
-  static final class DecayPeriod implements Name<Integer> {
-  }
-
   @NamedParameter(doc = "maximum value for each element", short_name = "max_val", default_value = "1e6")
   static final class MaxValue implements Name<Float> {
   }

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -80,7 +80,7 @@ final class NMFTrainer implements Trainer<NMFData> {
                      @Parameter(StepSize.class) final float stepSize,
                      @Parameter(Lambda.class) final float lambda,
                      @Parameter(DecayRate.class) final float decayRate,
-                     @Parameter(DecayPeriod.class) final int decayPeriod,
+                     @Parameter(DolphinParameters.DecayPeriod.class) final int decayPeriod,
                      @Parameter(DolphinParameters.NumTotalMiniBatches.class) final int numTotalMiniBatches,
                      @Parameter(PrintMatrices.class) final boolean printMatrices,
                      @Parameter(DolphinParameters.NumTrainerThreads.class) final int numTrainerThreads,


### PR DESCRIPTION
Job server has to support multiple jobs. On the other hand, `DecayPeriod` which is used in LASSO, MLR, NMF app, has same short name, but it is classified to app specific parameter. So different `DecayPeriod`s in different apps cause `ClassHierarchyException`.

This PR moves `DecayPeriod` from app specific parameter to `DolphinParameter`