### PR TITLE
[MINOR] Consider hyper-thread when determining the number of trainer threads

### DIFF
--- a/dolphin/async/bin/run_lda.sh
+++ b/dolphin/async/bin/run_lda.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_lda.sh -input sample_lda -local true -num_workers 4 -number_servers 2 -num_topics 10 -num_vocabs 17935 -max_num_epochs 3 -mini_batch_size 25 -num_worker_blocks 20 -max_num_eval_local 6 -timeout 180000 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3
+# ./run_lda.sh -input sample_lda -local true -num_workers 4 -number_servers 2 -num_topics 10 -num_vocabs 17935 -max_num_epochs 3 -mini_batch_size 25 -num_worker_blocks 20 -max_num_eval_local 6 -timeout 180000 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3 -hyper_thread_enabled false
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_mlr.sh
+++ b/dolphin/async/bin/run_mlr.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_mlr.sh -num_workers 4 -number_servers 2 -local true -input sample_mlr -max_num_eval_local 6 -test_data_path file://$(pwd)/sample_mlr_test -max_num_epochs 20 -mini_batch_size 54 -num_worker_blocks 10 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -lambda 0.005 -timeout 200000 -decay_period 5 -decay_rate 0.9 -num_trainer_threads 1 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3
+# ./run_mlr.sh -num_workers 4 -number_servers 2 -local true -input sample_mlr -max_num_eval_local 6 -test_data_path file://$(pwd)/sample_mlr_test -max_num_epochs 20 -mini_batch_size 54 -num_worker_blocks 10 -init_step_size 0.1 -classes 10 -features 784 -features_per_partition 392 -model_gaussian 0.001 -lambda 0.005 -timeout 200000 -decay_period 5 -decay_rate 0.9 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3 -hyper_thread_enabled false
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/bin/run_nmf.sh
+++ b/dolphin/async/bin/run_nmf.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_nmf.sh -max_num_epochs 50 -local true -number_servers 1 -num_workers 4 -max_num_eval_local 5 -input sample_nmf -mini_batch_size 4 -num_worker_blocks 25 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -decay_period 5 -decay_rate 0.9 -num_trainer_threads 1 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3
+# ./run_nmf.sh -max_num_epochs 50 -local true -number_servers 1 -num_workers 4 -max_num_eval_local 5 -input sample_nmf -mini_batch_size 4 -num_worker_blocks 25 -rank 30 -step_size 0.01 -print_mat true -timeout 300000 -decay_period 5 -decay_rate 0.9 -optimizer edu.snu.cay.dolphin.async.optimizer.impl.EmptyPlanOptimizer -optimization_interval_ms 3000 -delay_after_optimization_ms 10000 -opt_benefit_threshold 0.1 -server_metric_flush_period_ms 1000 -moving_avg_window_size 0 -metric_weight_factor 0.0 -num_initial_batch_metrics_to_skip 3 -min_num_required_batch_metrics 3 -hyper_thread_enabled false
 
 SELF_JAR=`echo ../target/dolphin-async-*-shaded.jar`
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/DolphinParameters.java
@@ -68,9 +68,9 @@ public final class DolphinParameters {
   public final class NumServerBlocks implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Number of threads to run Trainer with",
-      short_name = "num_trainer_threads", default_value = "1")
-  public final class NumTrainerThreads implements Name<Integer> {
+  @NamedParameter(doc = "Whether the hyper-thread is enabled, which determines the proper number of trainer threads.",
+      short_name = "hyper_thread_enabled", default_value = "false")
+  public final class HyperThreadEnabled implements Name<Boolean> {
   }
 
   @NamedParameter(doc = "Desired memory size for each worker evaluator (MBs)",

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/ETDolphinLauncher.java
@@ -223,7 +223,7 @@ public final class ETDolphinLauncher {
     final List<Class<? extends Name<?>>> serverParamList = Collections.emptyList();
 
     final List<Class<? extends Name<?>>> workerParamList = Arrays.asList(
-        NumTrainerThreads.class, MaxNumEpochs.class, NumTotalMiniBatches.class, TestDataPath.class);
+        HyperThreadEnabled.class, MaxNumEpochs.class, NumTotalMiniBatches.class, TestDataPath.class);
 
     // commonly used parameters for ML apps
     final List<Class<? extends Name<?>>> commonAppParamList = Arrays.asList(

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/jobserver/JobLauncher.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/jobserver/JobLauncher.java
@@ -145,7 +145,7 @@ public final class JobLauncher {
         NumWorkers.class, WorkerMemSize.class, NumWorkerCores.class,
         NumWorkerHandlerThreads.class, NumWorkerSenderThreads.class,
         WorkerHandlerQueueSize.class, WorkerSenderQueueSize.class,
-        NumWorkerBlocks.class, NumTrainerThreads.class, MaxNumEpochs.class,
+        NumWorkerBlocks.class, HyperThreadEnabled.class, MaxNumEpochs.class,
         NumTotalMiniBatches.class, TestDataPath.class, InputDir.class
     );
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/gbt/GBTTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/gbt/GBTTrainer.java
@@ -143,7 +143,7 @@ final class GBTTrainer implements Trainer<GBTData> {
                      @Parameter(TreeMaxDepth.class) final int treeMaxDepth,
                      @Parameter(LeafMinSize.class) final int leafMinSize,
                      @Parameter(MaxNumEpochs.class) final int maxNumEpochs,
-                     @Parameter(NumTrainerThreads.class) final int numTrainerThreads,
+                     @Parameter(HyperThreadEnabled.class) final boolean hyperThreadEnabled,
                      @Parameter(NumKeys.class) final int numKeys,
                      final GBTMetadataParser metadataParser) {
     this.modelAccessor = modelAccessor;
@@ -165,7 +165,8 @@ final class GBTTrainer implements Trainer<GBTData> {
     } else {  // if valueTypeNum != 0, value's type is categorical(FeatureType.CATEGORICAL).
       this.valueType = FeatureType.CATEGORICAL;
     }
-    this.numTrainerThreads = numTrainerThreads;
+    // Use the half of the processors if hyper-thread is on, since using virtual cores do not help for float-point ops.
+    this.numTrainerThreads = Runtime.getRuntime().availableProcessors() / (hyperThreadEnabled ? 2 : 1);
     this.executor = CatchableExecutors.newFixedThreadPool(numTrainerThreads);
   }
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/lda/SparseLDASampler.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.cay.dolphin.async.mlapps.lda;
 
+import edu.snu.cay.dolphin.async.DolphinParameters;
 import edu.snu.cay.dolphin.async.ModelHolder;
 import edu.snu.cay.dolphin.async.mlapps.lda.LDAParameters.*;
 import edu.snu.cay.utils.CatchableExecutors;
@@ -62,6 +63,7 @@ final class SparseLDASampler {
                            @Parameter(Beta.class) final double beta,
                            @Parameter(NumTopics.class) final int numTopics,
                            @Parameter(NumVocabs.class) final int numVocabs,
+                           @Parameter(DolphinParameters.HyperThreadEnabled.class) final boolean hyperThreadEnabled,
                            final ModelHolder<LDAModel> modelHolder) {
     this.alpha = alpha;
     this.beta = beta;
@@ -69,7 +71,8 @@ final class SparseLDASampler {
     this.numVocabs = numVocabs;
     this.modelHolder = modelHolder;
 
-    this.numTrainerThreads = Runtime.getRuntime().availableProcessors();
+    // Use the half of the processors if hyper-thread is on, since using virtual cores do not help for float-point ops.
+    this.numTrainerThreads = Runtime.getRuntime().availableProcessors() / (hyperThreadEnabled ? 2 : 1);
     this.executor = CatchableExecutors.newFixedThreadPool(numTrainerThreads);
   }
 

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/mlr/MLRTrainer.java
@@ -119,6 +119,7 @@ final class MLRTrainer implements Trainer<MLRData> {
                      @Parameter(Lambda.class) final float lambda,
                      @Parameter(DecayRate.class) final float decayRate,
                      @Parameter(DecayPeriod.class) final int decayPeriod,
+                     @Parameter(HyperThreadEnabled.class) final boolean hyperThreadEnabled,
                      @Parameter(DolphinParameters.NumTotalMiniBatches.class) final int numTotalMiniBatches,
                      final VectorFactory vectorFactory) {
     this.modelAccessor = modelAccessor;
@@ -143,7 +144,8 @@ final class MLRTrainer implements Trainer<MLRData> {
       throw new IllegalArgumentException("decay_period must be a positive value");
     }
 
-    this.numTrainerThreads = Runtime.getRuntime().availableProcessors();
+    // Use the half of the processors if hyper-thread is on, since using virtual cores do not help for float-point ops.
+    this.numTrainerThreads = Runtime.getRuntime().availableProcessors() / (hyperThreadEnabled ? 2 : 1);
     this.executor = CatchableExecutors.newFixedThreadPool(numTrainerThreads);
 
     this.classPartitionIndices = new ArrayList<>(numClasses * numPartitionsPerClass);

--- a/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
+++ b/dolphin/async/src/main/java/edu/snu/cay/dolphin/async/mlapps/nmf/NMFTrainer.java
@@ -85,6 +85,7 @@ final class NMFTrainer implements Trainer<NMFData> {
                      @Parameter(DecayPeriod.class) final int decayPeriod,
                      @Parameter(NumTotalMiniBatches.class) final int numTotalMiniBatches,
                      @Parameter(PrintMatrices.class) final boolean printMatrices,
+                     @Parameter(HyperThreadEnabled.class) final boolean hyperThreadEnabled,
                      final NMFModelGenerator modelGenerator,
                      final TrainingDataProvider<NMFData> trainingDataProvider) {
     this.modelAccessor = modelAccessor;
@@ -104,7 +105,8 @@ final class NMFTrainer implements Trainer<NMFData> {
     this.modelGenerator = modelGenerator;
     this.trainingDataProvider = trainingDataProvider;
 
-    this.numTrainerThreads = Runtime.getRuntime().availableProcessors();
+    // Use the half of the processors if hyper-thread is on, since using virtual cores do not help for float-point ops.
+    this.numTrainerThreads = Runtime.getRuntime().availableProcessors() / (hyperThreadEnabled ? 2 : 1);
     this.executor = CatchableExecutors.newFixedThreadPool(numTrainerThreads);
 
     // Note that this number of trainer threads does not consider hyper-thread.


### PR DESCRIPTION
In the applications that we are using for evaluation, the number of trainer threads are determined by the available processors that JVM gives via `Runtime.getRuntime().availableProcessors()`. However, this method counts the number of virtual cores as well, which is known for bad performance especially in the floating point operations. 

To address this problem, this PR adds `HyperThreadEnabled` parameter, with which we can determine the number of training threads toward a better performance.

(Note)
A cleaner solution is to disable the HT feature in the OS, but in the virtual environment like AWS EC2, the configuration is not easy to tune. So I ended up with the working solution as in this PR.