### PR TITLE
[MINOR] Fix error in ET's multiGetOrInit method

### DIFF
--- a/services/et/src/main/java/edu/snu/cay/services/et/evaluator/impl/TableImpl.java
+++ b/services/et/src/main/java/edu/snu/cay/services/et/evaluator/impl/TableImpl.java
@@ -365,7 +365,7 @@ public final class TableImpl<K, V, U> implements Table<K, V, U> {
         if (!remoteIdOptional.isPresent()) {
           final Map<K, V> localResultMap = new HashMap<>();
           for (final K key : keyList) {
-            final V output = tablet.get(blockId, key);
+            final V output = tablet.getOrInit(blockId, key);
             if (output != null) {
               localResultMap.put(key, output);
             }


### PR DESCRIPTION
This PR fixes a minor bug in local access path of ET's `multiGetOrInit` method.
This code is activated only when model table is collocated with workers.
