### PR TITLE
[CAY-1270] Use REEF-0.16.0 instead of snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.16.0-SNAPSHOT</reef.version>
+    <reef.version>0.16.0</reef.version>
     <hadoop.version>2.6.0</hadoop.version>
     <htrace.version>3.0.4</htrace.version>
     <avro.version>1.7.7</avro.version>


### PR DESCRIPTION
This PR changes the project to use REEF-0.16.0, a latest release, instead of custom snapshot.
I've confirmed that example apps work well with the change.