### PR TITLE
[MINOR] Update checkstyle plugin version to avoid security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     <jetty.version>6.1.26</jetty.version>
     <jackson.version>1.9.13</jackson.version>
     <protobuf.version>2.5.0</protobuf.version>
-    <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-    <checkstyle.version>7.2</checkstyle.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>8.18</checkstyle.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.5</powermock.version>
     <breeze.version>0.12</breeze.version>

--- a/ps/src/test/java/edu/snu/spl/cruise/ps/core/master/WorkerStateManagerTest.java
+++ b/ps/src/test/java/edu/snu/spl/cruise/ps/core/master/WorkerStateManagerTest.java
@@ -243,7 +243,7 @@ public class WorkerStateManagerTest {
    * @param workerIds a set of worker ids to be synchronized
    * @return a latch that indicates whether the workers passed the global barrier.
    */
-  private CountDownLatch callGlobalBarrier(final String ... workerIds) throws InterruptedException {
+  private CountDownLatch callGlobalBarrier(final String... workerIds) throws InterruptedException {
     final CountDownLatch latch = new CountDownLatch(workerIds.length);
 
     final Runnable[] threads = new Runnable[workerIds.length];

--- a/services/et/pom.xml
+++ b/services/et/pom.xml
@@ -48,8 +48,8 @@
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     <apache-rat-plugin.version>0.11</apache-rat-plugin.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-    <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-    <checkstyle.version>7.2</checkstyle.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>8.18</checkstyle.version>
     <build-helper.version>1.9.1</build-helper.version>
   </properties>
 


### PR DESCRIPTION
Github recently warned the potential security vulnerability, caused by Checkstyle plugin. 
```
Known moderate severity security vulnerability detected in com.puppycrawl.tools:checkstyle < 8.18 defined in pom.xml.
pom.xml update suggested: com.puppycrawl.tools:checkstyle ~> 8.18.
```

This PR updates its version, to which is known to have fixed the issue. 